### PR TITLE
feat(supabase): セットアップ基盤 (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Prisma (Supabase Postgres)
+# Pooled connection for runtime queries (required).
+DATABASE_URL="postgresql://postgres.<project-ref>:<password>@aws-0-<region>.pooler.supabase.com:6543/postgres?pgbouncer=true"
+# Direct connection for `prisma migrate` / `prisma db push` (no pooler).
+DIRECT_URL="postgresql://postgres.<project-ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres"
+
+# Supabase (public keys, safe to expose to the browser)
+NEXT_PUBLIC_SUPABASE_URL="https://<project-ref>.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY=""
+
+# Supabase service role key (server-only, never expose to the browser).
+# Bypasses RLS — use only from trusted server code.
+SUPABASE_SERVICE_ROLE_KEY=""

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -37,6 +37,31 @@ npm run dev
 
 `http://localhost:3000` を開く。
 
+## Supabase セットアップ (認証 / BaaS)
+
+認証 (Supabase Auth) と BaaS (Storage / Realtime) に Supabase を利用する。**DB アクセスは Prisma 経由** で Supabase Postgres に接続する方針のため、`@supabase/supabase-js` の `.from().select()` のような直接クエリは書かない (`.claude/rules/tech-stack.md § 2.5`)。
+
+本リポジトリのコードには Supabase クライアントの雛形と `proxy.ts` (セッション更新) が含まれるが、**プロジェクト作成と env 設定はユーザーが手動で行う必要がある**。
+
+### 手順
+
+1. [Supabase Dashboard](https://supabase.com/dashboard) で新規プロジェクトを作成する。
+2. **Project Settings → API** から以下を控える:
+   - Project URL → `NEXT_PUBLIC_SUPABASE_URL`
+   - `anon` public key → `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `service_role` key → `SUPABASE_SERVICE_ROLE_KEY` (server-only。漏らさない)
+3. **Project Settings → Database → Connection string** から以下を控える:
+   - **Transaction pooler** (port 6543) → `DATABASE_URL` (Prisma runtime 用)
+   - **Session pooler / Direct connection** (port 5432) → `DIRECT_URL` (`prisma migrate` / `db push` 用)
+4. `cp .env.example .env.local` で雛形をコピーし、上記値を埋める。
+5. `npm run db:push` を実行し、Prisma schema が Supabase Postgres に反映されることを確認する。
+
+### 方針メモ
+
+- DB read/write は Prisma 経由。`@supabase/supabase-js` のクエリ API は使わない。
+- RLS ポリシーには依存しない。認可は `src/proxy.ts` (Next.js 16 proxy = 旧 middleware) + `src/lib/auth.ts` の `requireAuth` / `requireRole` で行う (defense in depth)。
+- ログイン UI / `(protected)` ルートグループ / `requireAuth` の本実装は **issue #5** で対応する。本 issue はクライアント分離・env 雛形・セッション更新スケルトンまで。
+
 ## スクリプト
 
 | コマンド | 説明 |
@@ -64,6 +89,11 @@ src/
     LessonClient.tsx                                 # Monaco + 実行結果 UI
   lib/
     prisma.ts                                        # Prisma シングルトン
+    auth.ts                                          # requireAuth / requireRole (stub、#5 で実装)
+    supabase/
+      server.ts                                      # Server Component / Action / proxy 用 client
+      client.ts                                      # Browser 用 client
+  proxy.ts                                           # Next.js 16 proxy: Supabase セッション更新
 prisma/
   schema.prisma                                      # Course / Lesson / Progress
   seed.ts                                            # 初期データ

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "19.2.4",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "swr": "^2.4.1",
         "tsx": "^4.21.0",
         "zod": "^4.3.6"
       },
@@ -232,27 +233,8 @@
         "@electric-sql/pglite": "0.4.1"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1206,17 +1188,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
-      }
-    },
     "node_modules/@next/env": {
       "version": "16.2.4",
       "license": "MIT"
@@ -1979,6 +1950,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
@@ -2023,15 +2058,6 @@
         "@tailwindcss/oxide": "4.2.4",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.4"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/debug": {
@@ -4590,6 +4616,19 @@
         }
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
       "dev": true,
@@ -4741,6 +4780,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/valibot": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@monaco-editor/react": "^4.7.0",
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
+        "@supabase/ssr": "^0.10.2",
+        "@supabase/supabase-js": "^2.104.0",
         "next": "16.2.4",
         "pg": "^8.20.0",
         "prisma": "^7.7.0",
@@ -19,7 +21,6 @@
         "react-dom": "19.2.4",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
-        "swr": "^2.4.1",
         "tsx": "^4.21.0",
         "zod": "^4.3.6"
       },
@@ -1655,6 +1656,105 @@
       "version": "1.1.0",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.0.tgz",
+      "integrity": "sha512-Vs0ndL+s5an7rOmXtS/nbYnGXL8m+KXlCSrPIcw9bR96ma6qyLYILnE6syuM+rpDnf+Tg4PVNxNB2+oDwoy6mA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.0.tgz",
+      "integrity": "sha512-O8EyEz/RT1kfWhyJNpVc/VbLeBsohHGBVif/CI83zoMB+Iul/t/NIekH1/7RsH6kuO+b2D4wJhfiaW8Qr47sRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.0.tgz",
+      "integrity": "sha512-ynylEq6wduQEycj6pL3P+/yIfDQ+CTnBC5I6p+PzcAO2ybj9coAITVtMfboi+g/dacgMslN5MH73rXsRMB29+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.0.tgz",
+      "integrity": "sha512-9fUVDoTVAhn7a79+AmEx+asUlRtf2yBrji7TQckcKn/WK4hvAA9Lia9er+lnhuz3WNiF1x6kkA4x7bRCJrU+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.2.tgz",
+      "integrity": "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.102.1"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.0.tgz",
+      "integrity": "sha512-s2NHtuAWb9nldJ/fS62WnJE6edvCWn31rrO+FJKlAohs99qdVgtLegUReTU2H9WnZiQlVqaBtu386wt6/6lrRw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.0.tgz",
+      "integrity": "sha512-hILwhIjCB53G31jlHUe73NDEmrXudcjcYlVRuvNfEhzf0gyFQaFf7j6rd1UGmYZkFMOg//DFE8Iy9ZbNEgosVw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@supabase/auth-js": "2.104.0",
+        "@supabase/functions-js": "2.104.0",
+        "@supabase/postgrest-js": "2.104.0",
+        "@supabase/realtime-js": "2.104.0",
+        "@supabase/storage-js": "2.104.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "license": "Apache-2.0",
@@ -2012,6 +2112,15 @@
       "version": "3.0.3",
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "license": "ISC"
@@ -2192,6 +2301,19 @@
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -2562,6 +2684,15 @@
     "node_modules/http-status-codes": {
       "version": "2.3.0",
       "license": "MIT"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -4459,19 +4590,6 @@
         }
       }
     },
-    "node_modules/swr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
-      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
       "dev": true,
@@ -4625,15 +4743,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/valibot": {
       "version": "1.2.0",
       "license": "MIT",
@@ -4681,6 +4790,27 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@monaco-editor/react": "^4.7.0",
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.104.0",
     "next": "16.2.4",
     "pg": "^8.20.0",
     "prisma": "^7.7.0",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+export type Role = "ADMIN" | "USER";
+
+export type Session = {
+  userId: string;
+  email: string;
+  role: Role;
+};
+
+/**
+ * Returns the current authenticated session. Throws `UnauthorizedError` when
+ * no session is present.
+ *
+ * Stub: full implementation lands in issue #5 (Auth). Today this always throws
+ * so callers fail loudly if they reach the check before #5 ships.
+ */
+export async function requireAuth(): Promise<Session> {
+  throw new Error("requireAuth: not implemented (see #5)");
+}
+
+/**
+ * Returns the current session if its role matches `role`. Throws
+ * `ForbiddenError` on role mismatch and `UnauthorizedError` when unauthenticated.
+ *
+ * Stub: full implementation lands in issue #5.
+ */
+export async function requireRole(_role: Role): Promise<Session> {
+  throw new Error("requireRole: not implemented (see #5)");
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+let cached: SupabaseClient | null = null;
+
+export function createSupabaseBrowserClient(): SupabaseClient | null {
+  if (cached) return cached;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+
+  cached = createBrowserClient(url, anonKey);
+  return cached;
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { cookies } from "next/headers";
+
+function readEnv(): { url: string; anonKey: string } | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+  return { url, anonKey };
+}
+
+/**
+ * Create a Supabase client for Server Components / Server Actions / Route Handlers.
+ * Returns `null` when Supabase env vars are not set so callers can fall back safely
+ * during the pre-auth PoC phase (see issue #4 / #5).
+ */
+export async function createSupabaseServerClient(): Promise<SupabaseClient | null> {
+  const env = readEnv();
+  if (!env) return null;
+
+  const cookieStore = await cookies();
+
+  return createServerClient(env.url, env.anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // `setAll` is called from a Server Component where cookies are read-only.
+          // Session refresh is handled by `src/proxy.ts`, so this is safe to ignore.
+        }
+      },
+    },
+  });
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,50 @@
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * Next.js 16 proxy (formerly middleware) — refreshes the Supabase auth session
+ * so Server Components see an up-to-date token. Auth gating (redirects, role
+ * checks) is intentionally deferred to issue #5; this file only keeps the
+ * session cookie fresh.
+ *
+ * When Supabase env vars are missing (pre-setup), the proxy falls through so
+ * the dev server keeps working without credentials.
+ */
+export async function proxy(request: NextRequest): Promise<NextResponse> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  let response = NextResponse.next({ request });
+
+  if (!url || !anonKey) return response;
+
+  const supabase = createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        response = NextResponse.next({ request });
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  // Touch the session so `@supabase/ssr` performs a refresh if needed and
+  // writes the rotated cookies via `setAll`.
+  await supabase.auth.getUser();
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    // Run on all paths except Next.js internals and static assets.
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,6 @@
+// Note: エッジランタイムで動作するため `import 'server-only'` は付けない
+// (tech-stack.md § 2.12 の例外)。next.config / proxy (旧 middleware) 実行環境の
+// 制約を参照。Node.js 専用 API / `server-only` モジュールはここに持ち込めない。
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,16 +35,22 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
     },
   });
 
-  // Touch the session so `@supabase/ssr` performs a refresh if needed and
-  // writes the rotated cookies via `setAll`.
-  await supabase.auth.getUser();
+  try {
+    // Touch the session so `@supabase/ssr` performs a refresh if needed and
+    // writes the rotated cookies via `setAll`. Session refresh is best-effort:
+    // transient Supabase outages or malformed cookies must not break rendering.
+    await supabase.auth.getUser();
+  } catch {
+    // Swallow; callers fall back to an unauthenticated state.
+  }
 
   return response;
 }
 
 export const config = {
   matcher: [
-    // Run on all paths except Next.js internals and static assets.
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    // Skip Next.js internals, API routes, and static assets.
+    // API routes that need auth perform their own requireAuth check (#5).
+    "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

- `@supabase/supabase-js` + `@supabase/ssr` を追加し、認証 (Supabase Auth) と BaaS (Storage / Realtime) の基盤を整備する
- `src/lib/supabase/{server,client}.ts` で Server / Browser クライアントを分離 (`server.ts` は `server-only` ガード付き)
- `src/proxy.ts` (Next.js 16 で `middleware` から改名された file convention) に Supabase セッション更新の最小実装を追加
- `src/lib/auth.ts` に `requireAuth` / `requireRole` の型スケルトンを配置 (`architecture.md § 6.5` 準拠、本実装は #5)
- `.env.example` / README に Supabase 手動セットアップ手順を記述

## 方針メモ

- DB アクセスは **Prisma 経由** で Supabase Postgres に接続する (`tech-stack.md § 2.5`)。`@supabase/supabase-js` の `.from().select()` は使わない
- 認可は `proxy.ts` + `requireAuth` / `requireRole` で実施。RLS には依存しない (defense in depth)
- Next.js 16 では `middleware.ts` が deprecated。本 PR では `src/proxy.ts` を使用 (CLAUDE.md "Heed deprecation notices" に従う)
- env 未設定時は Supabase クライアント生成が `null` を返し、proxy もフォールスルーする → Supabase プロジェクト作成前でも dev server が起動する

### proxy matcher が `/api/*` を除外している理由

`src/proxy.ts` の `config.matcher` では `_next/static` / `_next/image` / 静的アセットに加えて `/api/*` も除外している。理由:

1. **エッジランタイムでの不要な実行回避** — proxy は Edge で走るため、API ルートのたびにセッション refresh を走らせると Supabase Auth への network call が増え、レイテンシとコストが無視できない
2. **責務の分離** — 書き込み系は Server Action に集約する方針 (`tech-stack.md § 2.3`)。Route Handler (GET-only) / Server Action はいずれも **実行側で `requireAuth()` / `requireRole()` を個別に呼ぶ** ので、proxy 側で session を温める動機が弱い
3. **既知の limitation (#5 で再検討)** — セッション期限切れ直前の古いトークンで API に到達したリクエストは、proxy が走らないため refresh されない。この挙動は認証を実装する #5 の時点で改めて評価する (Route Handler 側で `createSupabaseServerClient()` を呼んだ時点で refresh が走るため、実用上の影響は限定的である想定)

## ユーザー手動タスク (本 PR では対応不可)

1. [Supabase Dashboard](https://supabase.com/dashboard) で新規プロジェクト作成
2. Project Settings → API から `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY` を取得
3. Database → Connection string から **Transaction pooler (6543)** = `DATABASE_URL`、**Direct/Session pooler (5432)** = `DIRECT_URL` を取得
4. `cp .env.example .env.local` して値を埋める
5. `npm run db:push` で Supabase Postgres にスキーマが通るか確認

詳細は README の「Supabase セットアップ」節を参照。

## 本 PR に含まれないもの (→ #5)

- ログイン / signup UI
- `(protected)` ルートグループと proxy での redirect
- `requireAuth` / `requireRole` の本実装 (現状は `throw`)
- API ルート到達時のセッション refresh の扱い (上記 matcher の limitation)

## Test plan

- [x] `npx tsc --noEmit` が本 PR で追加したファイルに対してエラーを出さない (既存の型エラーは本 PR 対象外)
- [x] `npx biome check .` pass
- [ ] 手動: `.env.local` に Supabase env を設定 → `npm run dev` でセッション更新が 500 にならない
- [ ] 手動: env 未設定でも dev server が起動しフォールスルーする

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)