### PR TITLE
feat(ui): デフォルトをダークモードに固定 (#23)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,8 +20,13 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
-      <body className="flex min-h-full flex-col bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50">
+    <html
+      lang="ja"
+      className={`dark ${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      style={{ colorScheme: "dark" }}
+      suppressHydrationWarning
+    >
+      <body className="bg-background text-foreground flex min-h-full flex-col">
         <SwrProvider>{children}</SwrProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- 全体の表示をダークモード固定に変更
- \`<html>\` に \`className=\"dark\"\` + \`style={{ colorScheme: 'dark' }}\` 追加
- \`<body>\` のハードコード \`bg-white text-zinc-900\` を削除し shadcn の CSS variables (\`bg-background text-foreground\`) に委譲

## 動作確認
- [x] \`npm run check\` pass
- [x] \`npx tsc --noEmit\` pass
- [x] \`npm run build\` pass

## Notes
- ライトモード切替 UI は別 issue で扱う想定 (今回は固定)
- \`suppressHydrationWarning\` は将来 theme toggle を入れたときの noise 対策

Closes #23