### PR TITLE
feat(errors): エラーハンドリング整備 (AppError / error page) (#30)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -343,6 +343,7 @@ export function handleUnknownError(error: unknown): Error;
 
 - 各 `AppError` は `httpStatus` を readonly で持つ。Route Handler 側は `isKnownAppError(e)` で分岐し `e.httpStatus` でレスポンスを返す。
 - Server Action / Service 層では従来どおり throw に徹する。HTTP レスポンスへの変換は API 境界の責務。
+- **Route Handler は Server Action と違って `try` 内で `requireAuth()` を呼んで `UnauthorizedError` をキャッチし 401 を返してよい**。Server Action は `error.tsx` 画面に伝播させるために `requireAuth()` を `try` の外に置くが、Route Handler (`src/app/api/**`) は fetch クライアントが `res.status` を見て分岐する設計のため、`isKnownAppError(e)` で捕捉して `Response.json({ error: e.name }, { status: e.httpStatus })` を返すのが正しい。
 
 #### エラーページの責務（`src/app/`）
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -301,21 +301,34 @@ export abstract class BaseRepository {
 Service / Server Action から参照する以下のユーティリティは **契約を固定** する。AI エージェントは独自シグネチャで再実装しない。実装自体は未作成なので、新規に作るときはこの契約を守る。
 
 ```typescript
-// src/lib/errors.ts (想定)
+// src/lib/errors.ts
 import 'server-only';
 
 export class ValidationError extends Error {
   readonly name = 'ValidationError';
-}
-export class NotFoundError extends Error {
-  readonly name = 'NotFoundError';
+  readonly httpStatus = 400;
 }
 export class UnauthorizedError extends Error {
   readonly name = 'UnauthorizedError';
+  readonly httpStatus = 401;
 }
 export class ForbiddenError extends Error {
   readonly name = 'ForbiddenError';
+  readonly httpStatus = 403;
 }
+export class NotFoundError extends Error {
+  readonly name = 'NotFoundError';
+  readonly httpStatus = 404;
+}
+
+export type AppError =
+  | ValidationError
+  | UnauthorizedError
+  | ForbiddenError
+  | NotFoundError;
+
+/** Route Handler / API で known error を HTTP status に写像するための型ガード。 */
+export function isKnownAppError(error: unknown): error is AppError;
 
 /**
  * 想定外の error を既知の Error サブクラスに正規化して返す。
@@ -325,15 +338,25 @@ export class ForbiddenError extends Error {
  *     throw handleUnknownError(error);
  *   }
  */
-export function handleUnknownError(error: unknown): Error {
-  if (error instanceof ValidationError) return error;
-  if (error instanceof NotFoundError) return error;
-  if (error instanceof UnauthorizedError) return error;
-  if (error instanceof ForbiddenError) return error;
-  if (error instanceof Error) return error;
-  return new Error(typeof error === 'string' ? error : 'Unknown error');
-}
+export function handleUnknownError(error: unknown): Error;
 ```
+
+- 各 `AppError` は `httpStatus` を readonly で持つ。Route Handler 側は `isKnownAppError(e)` で分岐し `e.httpStatus` でレスポンスを返す。
+- Server Action / Service 層では従来どおり throw に徹する。HTTP レスポンスへの変換は API 境界の責務。
+
+#### エラーページの責務（`src/app/`）
+
+Next.js App Router の error boundary / 404 ページは以下の役割分担で配置する。AI エージェントは新規作成・編集時にこの分担を崩さない。
+
+| ファイル | 役割 | Component 種別 |
+| :-- | :-- | :-- |
+| `src/app/error.tsx` | route 単位の実行時エラーの受け皿。`reset()` で再試行、ホーム導線を提示する。 | `'use client'` 必須 |
+| `src/app/global-error.tsx` | root layout 自体が壊れた時の最後の砦。自前で `<html>` / `<body>` を描画する。 | `'use client'` 必須 |
+| `src/app/not-found.tsx` | `notFound()` / 未ヒット URL のページ。 | Server Component |
+| `src/app/(protected)/error.tsx`（任意） | 認証領域専用のエラー UI が必要な場合のみ追加。 | `'use client'` 必須 |
+
+- `error.tsx` は production では `error.message` を生出ししない。dev のみ `process.env.NODE_ENV !== 'production'` でデバッグ情報を出す。
+- shadcn `Card` / `Button` + lucide アイコンを使い、ユーザーに次のアクション（再試行 / ホームへ戻る）を明示する。
 
 ```typescript
 // src/lib/auth.ts

--- a/src/app/api/progress/route.ts
+++ b/src/app/api/progress/route.ts
@@ -1,5 +1,5 @@
 import { requireAuth } from "@/lib/auth";
-import { UnauthorizedError } from "@/lib/errors";
+import { isKnownAppError } from "@/lib/errors";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
 
 export const runtime = "nodejs";
@@ -11,8 +11,8 @@ export async function GET() {
     const lessonIds = await getCompletedLessonIdsByUser(session.userId);
     return Response.json({ lessonIds });
   } catch (error) {
-    if (error instanceof UnauthorizedError) {
-      return Response.json({ error: "unauthorized" }, { status: 401 });
+    if (isKnownAppError(error)) {
+      return Response.json({ error: error.name }, { status: error.httpStatus });
     }
     throw error;
   }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -13,7 +13,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-export default function GlobalRouteError({
+export default function ErrorPage({
   error,
   reset,
 }: {
@@ -28,7 +28,7 @@ export default function GlobalRouteError({
 
   return (
     <main className="flex min-h-[60vh] items-center justify-center p-6">
-      <Card className="w-full max-w-md">
+      <Card role="alert" className="w-full max-w-md">
         <CardHeader>
           <div className="mb-2 flex items-center gap-2 text-destructive">
             <AlertTriangle className="size-5" aria-hidden />

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { AlertTriangle, Home, RotateCcw } from "lucide-react";
+import Link from "next/link";
+import { useEffect } from "react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function GlobalRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const isDev = process.env.NODE_ENV !== "production";
+
+  return (
+    <main className="flex min-h-[60vh] items-center justify-center p-6">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <div className="mb-2 flex items-center gap-2 text-destructive">
+            <AlertTriangle className="size-5" aria-hidden />
+            <CardTitle>エラーが発生しました</CardTitle>
+          </div>
+          <CardDescription>
+            一時的な問題の可能性があります。もう一度お試しいただくか、ホームへ戻ってください。
+          </CardDescription>
+        </CardHeader>
+        {isDev && (
+          <CardContent>
+            <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs whitespace-pre-wrap">
+              {error.message}
+              {error.digest && `\n\ndigest: ${error.digest}`}
+            </pre>
+          </CardContent>
+        )}
+        <CardFooter className="flex justify-end gap-2">
+          <Link href="/" className={buttonVariants({ variant: "outline" })}>
+            <Home className="size-4" aria-hidden />
+            ホームへ
+          </Link>
+          <Button onClick={reset} type="button">
+            <RotateCcw className="size-4" aria-hidden />
+            もう一度試す
+          </Button>
+        </CardFooter>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -15,6 +15,11 @@ export default function GlobalError({
 
   return (
     <html lang="ja">
+      <head>
+        <meta charSet="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>エラー</title>
+      </head>
       <body
         style={{
           margin: 0,

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "system-ui, sans-serif",
+          background: "#0a0a0a",
+          color: "#fafafa",
+          padding: "1.5rem",
+        }}
+      >
+        <div style={{ maxWidth: 480, textAlign: "center" }}>
+          <h1 style={{ fontSize: "1.25rem", marginBottom: "0.75rem" }}>
+            重大なエラーが発生しました
+          </h1>
+          <p style={{ marginBottom: "1.25rem", color: "#a1a1aa" }}>
+            アプリケーションの読み込みに失敗しました。ページをリロードしてお試しください。
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              padding: "0.5rem 1rem",
+              borderRadius: 8,
+              border: "1px solid #3f3f46",
+              background: "#18181b",
+              color: "#fafafa",
+              cursor: "pointer",
+            }}
+          >
+            リロード
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+import { FileQuestion, Home } from "lucide-react";
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-[60vh] items-center justify-center p-6">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+            <FileQuestion className="size-5" aria-hidden />
+            <CardTitle>ページが見つかりません</CardTitle>
+          </div>
+          <CardDescription>
+            お探しのページは存在しないか、移動または削除された可能性があります。
+          </CardDescription>
+        </CardHeader>
+        <CardFooter className="flex justify-end">
+          <Link href="/" className={buttonVariants({ variant: "default" })}>
+            <Home className="size-4" aria-hidden />
+            ホームへ戻る
+          </Link>
+        </CardFooter>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,7 +6,7 @@ import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/comp
 export default function NotFound() {
   return (
     <main className="flex min-h-[60vh] items-center justify-center p-6">
-      <Card className="w-full max-w-md">
+      <Card role="status" className="w-full max-w-md">
         <CardHeader>
           <div className="mb-2 flex items-center gap-2 text-muted-foreground">
             <FileQuestion className="size-5" aria-hidden />

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -2,25 +2,37 @@ import "server-only";
 
 export class ValidationError extends Error {
   readonly name = "ValidationError";
-}
-
-export class NotFoundError extends Error {
-  readonly name = "NotFoundError";
+  readonly httpStatus = 400;
 }
 
 export class UnauthorizedError extends Error {
   readonly name = "UnauthorizedError";
+  readonly httpStatus = 401;
 }
 
 export class ForbiddenError extends Error {
   readonly name = "ForbiddenError";
+  readonly httpStatus = 403;
+}
+
+export class NotFoundError extends Error {
+  readonly name = "NotFoundError";
+  readonly httpStatus = 404;
+}
+
+export type AppError = ValidationError | UnauthorizedError | ForbiddenError | NotFoundError;
+
+export function isKnownAppError(error: unknown): error is AppError {
+  return (
+    error instanceof ValidationError ||
+    error instanceof UnauthorizedError ||
+    error instanceof ForbiddenError ||
+    error instanceof NotFoundError
+  );
 }
 
 export function handleUnknownError(error: unknown): Error {
-  if (error instanceof ValidationError) return error;
-  if (error instanceof NotFoundError) return error;
-  if (error instanceof UnauthorizedError) return error;
-  if (error instanceof ForbiddenError) return error;
+  if (isKnownAppError(error)) return error;
   if (error instanceof Error) return error;
   return new Error(typeof error === "string" ? error : "Unknown error");
 }


### PR DESCRIPTION
## Summary

Issue #30 対応。`lib/errors.ts` に HTTP ステータス情報と型ガードを加え、Next.js App Router の error boundary / 404 ページを整備してユーザーのネクストアクション (再試行 / ホームへ戻る) を誘導する。

- `AppError` クラスに `readonly httpStatus` を追加 (400 / 401 / 403 / 404)
- `AppError` union + `isKnownAppError()` 型ガード追加
- `src/app/error.tsx` / `not-found.tsx` / `global-error.tsx` を新規追加 (shadcn Card + Button + lucide icon)
- `/api/progress` を `isKnownAppError` ベースの分岐に書き換え
- `.claude/rules/architecture.md § 6.5` に `httpStatus` / `isKnownAppError` / error ページの責務を追記

## Test plan

- [x] `npm run check` (biome) pass
- [x] `npm run build` pass
- [ ] `/courses/nope` 等 未ヒット URL → `not-found.tsx` が表示される
- [ ] route 内で throw させて `error.tsx` の UI と `reset()` / ホーム導線が機能する
- [ ] `/api/progress` 未ログイン時 → 401 で `{ error: "UnauthorizedError" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)