### PR TITLE
feat(dashboard): UGC クリエイターダッシュボード (フェーズ 1) (#26)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -91,14 +91,23 @@ src/
 ```
 src/
 ├── app/
-│   ├── page.tsx                                  # 現状は prisma を直接呼んでいる
+│   ├── (protected)/
+│   │   ├── page.tsx                              # learner view (isPublished=true コースのみ)
+│   │   ├── courses/[slug]/page.tsx
+│   │   ├── courses/[slug]/lessons/[lessonSlug]/
+│   │   │   ├── page.tsx
+│   │   │   ├── _components/LessonClient.tsx       # ページ固有 (private folder)
+│   │   │   └── _hooks/useLessonRunner.ts          # ページ固有 (private folder)
+│   │   └── dashboard/                             # UGC クリエイターダッシュボード
+│   │       ├── layout.tsx
+│   │       ├── page.tsx                          # 自分のコース一覧 (author 認可)
+│   │       ├── _components/                      # dashboard 共有 UI
+│   │       └── courses/
+│   │           ├── new/                          # Course 作成フォーム
+│   │           └── [courseId]/                   # Course 編集 + レッスン一覧
+│   │               └── lessons/{new,[lessonId]}/ # Lesson 作成 / 編集
 │   ├── layout.tsx
 │   ├── globals.css
-│   ├── courses/[slug]/page.tsx
-│   ├── courses/[slug]/lessons/[lessonSlug]/
-│   │   ├── page.tsx
-│   │   ├── _components/LessonClient.tsx           # ページ固有 (private folder)
-│   │   └── _hooks/useLessonRunner.ts              # ページ固有 (private folder)
 │   └── api/
 │       ├── run/route.ts                          # POST、Server Action 移行予定
 │       └── progress/route.ts                     # POST、Server Action 移行予定
@@ -106,6 +115,7 @@ src/
     └── prisma.ts
 prisma/
 ├── schema.prisma
+├── migrations/                                   # prisma migrate dev で生成、commit 対象
 └── seed.ts
 docker-compose.yml
 ```
@@ -124,6 +134,18 @@ docker-compose.yml
   - `requireRole('ADMIN' | 'USER' | ...)` — ロール必須のアクション
   - いずれも `src/lib/auth.ts`（`import 'server-only';`）に実装する。
 - middleware 認証だけに頼らない理由: Route Handler が middleware の matcher から漏れる設計ミスが起きやすく、Server Action も `Next-Action` header 付き POST で発火しうるため。Defense in depth。
+
+### 3.1 UGC の authorId ベース認可
+
+UGC (ユーザー投稿コース・レッスン) の所有権チェックは、`src/services/authorGuard.ts` の 2 つの関数で **必ず** 行う。Service 層で直接 `authorId` を比較しない。
+
+```typescript
+// 違ったら ForbiddenError / NotFoundError を throw
+ensureAuthorOwnsCourse(courseId: string, authorId: string): Promise<Course>;
+ensureAuthorOwnsLesson(lessonId: string, authorId: string): Promise<Lesson>;
+```
+
+`ensureAuthorOwnsLesson` は経由する Course の authorId も検証する。認可 error は safe-action middleware を通じて `error.tsx` に伝播する。Service 側は `ctx.userId` を service 関数に渡すだけ（Action で分岐しない）。
 
 ---
 

--- a/prisma/migrations/20260424105831_add_ugc_fields_to_course_lesson/migration.sql
+++ b/prisma/migrations/20260424105831_add_ugc_fields_to_course_lesson/migration.sql
@@ -7,3 +7,9 @@ ALTER TABLE "Lesson" ADD COLUMN     "is_published" BOOLEAN NOT NULL DEFAULT fals
 
 -- AddForeignKey
 ALTER TABLE "Course" ADD CONSTRAINT "Course_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "profiles"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill: pre-UGC rows are treated as published so the learner view is not
+-- emptied out when this migration is deployed to production. New rows still
+-- default to false (UGC drafts stay private until the author publishes).
+UPDATE "Course" SET "is_published" = true;
+UPDATE "Lesson" SET "is_published" = true;

--- a/prisma/migrations/20260424105831_add_ugc_fields_to_course_lesson/migration.sql
+++ b/prisma/migrations/20260424105831_add_ugc_fields_to_course_lesson/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "Course" ADD COLUMN     "author_id" UUID,
+ADD COLUMN     "is_published" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Lesson" ADD COLUMN     "is_published" BOOLEAN NOT NULL DEFAULT false;
+
+-- AddForeignKey
+ALTER TABLE "Course" ADD CONSTRAINT "Course_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "profiles"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260424125516_add_updated_at_and_indexes/migration.sql
+++ b/prisma/migrations/20260424125516_add_updated_at_and_indexes/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable: add NOT NULL updated_at with a transient DEFAULT so existing
+-- rows get backfilled with NOW(), then drop the default so subsequent writes
+-- are driven by Prisma's @updatedAt (schema has no @default(now())).
+ALTER TABLE "Course" ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "Course" ALTER COLUMN  "updated_at" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Lesson" ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "Lesson" ALTER COLUMN  "updated_at" DROP DEFAULT;
+
+-- CreateIndex
+CREATE INDEX "Course_author_id_idx" ON "Course"("author_id");
+
+-- CreateIndex
+CREATE INDEX "Course_is_published_idx" ON "Course"("is_published");
+
+-- CreateIndex
+CREATE INDEX "Lesson_courseId_is_published_idx" ON "Lesson"("courseId", "is_published");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,10 @@ model Course {
   isPublished Boolean  @default(false) @map("is_published")
   lessons     Lesson[]
   createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@index([authorId])
+  @@index([isPublished])
 }
 
 model Lesson {
@@ -32,8 +36,10 @@ model Lesson {
   isPublished    Boolean    @default(false) @map("is_published")
   progress       Progress[]
   createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt @map("updated_at")
 
   @@unique([courseId, slug])
+  @@index([courseId, isPublished])
 }
 
 model Progress {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,9 @@ model Course {
   title       String
   description String
   order       Int
+  authorId    String?  @db.Uuid @map("author_id")
+  author      Profile? @relation(fields: [authorId], references: [id], onDelete: SetNull)
+  isPublished Boolean  @default(false) @map("is_published")
   lessons     Lesson[]
   createdAt   DateTime @default(now())
 }
@@ -26,6 +29,7 @@ model Lesson {
   starterCode    String
   expectedOutput String?
   order          Int
+  isPublished    Boolean    @default(false) @map("is_published")
   progress       Progress[]
   createdAt      DateTime   @default(now())
 
@@ -52,6 +56,7 @@ model Profile {
   createdAt DateTime   @default(now()) @map("created_at")
   updatedAt DateTime   @updatedAt      @map("updated_at")
   progress  Progress[]
+  courses   Course[]
 
   @@map("profiles")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -839,6 +839,7 @@ async function main() {
         title: course.title,
         description: course.description,
         order: course.order,
+        isPublished: true,
         lessons: {
           create: course.lessons.map((l) => ({
             slug: l.slug,
@@ -847,6 +848,7 @@ async function main() {
             contentMd: l.contentMd,
             starterCode: l.starterCode,
             expectedOutput: l.expectedOutput,
+            isPublished: true,
           })),
         },
       },

--- a/src/actions/dashboard/course.ts
+++ b/src/actions/dashboard/course.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { actionClient } from "@/lib/safe-action";
+import {
+  createCourse,
+  deleteCourse,
+  togglePublishCourse,
+  updateCourse,
+} from "@/services/courseService";
+import {
+  CreateCourseSchema,
+  DeleteCourseSchema,
+  TogglePublishCourseSchema,
+  UpdateCourseSchema,
+} from "@/types/course";
+
+function revalidateDashboardAndCourses(): void {
+  revalidatePath("/dashboard", "layout");
+  revalidatePath("/", "layout");
+}
+
+export const createCourseAction = actionClient
+  .inputSchema(CreateCourseSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const course = await createCourse({
+      authorId: ctx.userId,
+      ...parsedInput,
+    });
+    revalidateDashboardAndCourses();
+    return { id: course.id, slug: course.slug };
+  });
+
+export const updateCourseAction = actionClient
+  .inputSchema(UpdateCourseSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const course = await updateCourse({
+      authorId: ctx.userId,
+      ...parsedInput,
+    });
+    revalidateDashboardAndCourses();
+    return { id: course.id, slug: course.slug };
+  });
+
+export const deleteCourseAction = actionClient
+  .inputSchema(DeleteCourseSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    await deleteCourse({
+      id: parsedInput.id,
+      authorId: ctx.userId,
+    });
+    revalidateDashboardAndCourses();
+    return { id: parsedInput.id };
+  });
+
+export const togglePublishCourseAction = actionClient
+  .inputSchema(TogglePublishCourseSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const course = await togglePublishCourse({
+      id: parsedInput.id,
+      authorId: ctx.userId,
+      isPublished: parsedInput.isPublished,
+    });
+    revalidateDashboardAndCourses();
+    return { id: course.id, isPublished: course.isPublished };
+  });

--- a/src/actions/dashboard/lesson.ts
+++ b/src/actions/dashboard/lesson.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { actionClient } from "@/lib/safe-action";
+import {
+  createLesson,
+  deleteLesson,
+  togglePublishLesson,
+  updateLesson,
+} from "@/services/lessonService";
+import {
+  CreateLessonSchema,
+  DeleteLessonSchema,
+  TogglePublishLessonSchema,
+  UpdateLessonSchema,
+} from "@/types/lesson";
+
+function revalidateDashboardAndCourses(): void {
+  revalidatePath("/dashboard", "layout");
+  revalidatePath("/", "layout");
+}
+
+export const createLessonAction = actionClient
+  .inputSchema(CreateLessonSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const lesson = await createLesson({
+      authorId: ctx.userId,
+      ...parsedInput,
+    });
+    revalidateDashboardAndCourses();
+    return { id: lesson.id, slug: lesson.slug, courseId: lesson.courseId };
+  });
+
+export const updateLessonAction = actionClient
+  .inputSchema(UpdateLessonSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const lesson = await updateLesson({
+      authorId: ctx.userId,
+      ...parsedInput,
+    });
+    revalidateDashboardAndCourses();
+    return { id: lesson.id, slug: lesson.slug, courseId: lesson.courseId };
+  });
+
+export const deleteLessonAction = actionClient
+  .inputSchema(DeleteLessonSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    await deleteLesson({
+      id: parsedInput.id,
+      authorId: ctx.userId,
+    });
+    revalidateDashboardAndCourses();
+    return { id: parsedInput.id };
+  });
+
+export const togglePublishLessonAction = actionClient
+  .inputSchema(TogglePublishLessonSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const lesson = await togglePublishLesson({
+      id: parsedInput.id,
+      authorId: ctx.userId,
+      isPublished: parsedInput.isPublished,
+    });
+    revalidateDashboardAndCourses();
+    return { id: lesson.id, isPublished: lesson.isPublished };
+  });

--- a/src/app/(protected)/dashboard/_components/CourseListItem.tsx
+++ b/src/app/(protected)/dashboard/_components/CourseListItem.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { useTransition } from "react";
+import { togglePublishCourseAction } from "@/actions/dashboard/course";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { DeleteCourseButton } from "./DeleteCourseButton";
+import { PublishBadge } from "./PublishBadge";
+
+type Props = {
+  course: {
+    id: string;
+    slug: string;
+    title: string;
+    description: string;
+    isPublished: boolean;
+    lessonCount: number;
+  };
+};
+
+export function CourseListItem({ course }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  const onToggle = () => {
+    startTransition(async () => {
+      await togglePublishCourseAction({
+        id: course.id,
+        isPublished: !course.isPublished,
+      });
+    });
+  };
+
+  return (
+    <Card size="sm">
+      <CardContent className="flex items-center gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <Link
+              href={`/dashboard/courses/${course.id}`}
+              className="truncate font-semibold hover:underline"
+            >
+              {course.title}
+            </Link>
+            <PublishBadge isPublished={course.isPublished} />
+          </div>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            /{course.slug} · レッスン {course.lessonCount} 件
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            onClick={onToggle}
+            disabled={isPending}
+            size="sm"
+            type="button"
+            variant={course.isPublished ? "outline" : "default"}
+          >
+            {course.isPublished ? "非公開にする" : "公開する"}
+          </Button>
+          <DeleteCourseButton courseId={course.id} title={course.title} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(protected)/dashboard/_components/DeleteCourseButton.tsx
+++ b/src/app/(protected)/dashboard/_components/DeleteCourseButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useTransition } from "react";
+import { deleteCourseAction } from "@/actions/dashboard/course";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  courseId: string;
+  title: string;
+};
+
+export function DeleteCourseButton({ courseId, title }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (!window.confirm(`コース「${title}」を削除しますか？\nレッスンも一緒に削除されます。`)) {
+      return;
+    }
+    startTransition(async () => {
+      await deleteCourseAction({ id: courseId });
+    });
+  };
+
+  return (
+    <Button
+      aria-label={`コース「${title}」を削除`}
+      disabled={isPending}
+      onClick={onClick}
+      size="icon-sm"
+      type="button"
+      variant="destructive"
+    >
+      <Trash2 aria-hidden="true" />
+    </Button>
+  );
+}

--- a/src/app/(protected)/dashboard/_components/DeleteLessonButton.tsx
+++ b/src/app/(protected)/dashboard/_components/DeleteLessonButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useTransition } from "react";
+import { deleteLessonAction } from "@/actions/dashboard/lesson";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  lessonId: string;
+  title: string;
+};
+
+export function DeleteLessonButton({ lessonId, title }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (!window.confirm(`レッスン「${title}」を削除しますか？`)) {
+      return;
+    }
+    startTransition(async () => {
+      await deleteLessonAction({ id: lessonId });
+    });
+  };
+
+  return (
+    <Button
+      aria-label={`レッスン「${title}」を削除`}
+      disabled={isPending}
+      onClick={onClick}
+      size="icon-sm"
+      type="button"
+      variant="destructive"
+    >
+      <Trash2 aria-hidden="true" />
+    </Button>
+  );
+}

--- a/src/app/(protected)/dashboard/_components/PublishBadge.tsx
+++ b/src/app/(protected)/dashboard/_components/PublishBadge.tsx
@@ -1,0 +1,19 @@
+import { Badge } from "@/components/ui/badge";
+
+export function PublishBadge({ isPublished }: { isPublished: boolean }) {
+  if (isPublished) {
+    return (
+      <Badge
+        className="bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+        variant="secondary"
+      >
+        公開
+      </Badge>
+    );
+  }
+  return (
+    <Badge className="text-zinc-500" variant="outline">
+      非公開
+    </Badge>
+  );
+}

--- a/src/app/(protected)/dashboard/courses/[courseId]/_components/LessonListRow.tsx
+++ b/src/app/(protected)/dashboard/courses/[courseId]/_components/LessonListRow.tsx
@@ -57,7 +57,7 @@ export function LessonListRow({ courseId, lesson }: Props) {
             type="button"
             variant={lesson.isPublished ? "outline" : "default"}
           >
-            {lesson.isPublished ? "非公開" : "公開"}
+            {lesson.isPublished ? "非公開にする" : "公開する"}
           </Button>
           <DeleteLessonButton lessonId={lesson.id} title={lesson.title} />
         </div>

--- a/src/app/(protected)/dashboard/courses/[courseId]/_components/LessonListRow.tsx
+++ b/src/app/(protected)/dashboard/courses/[courseId]/_components/LessonListRow.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { useTransition } from "react";
+import { togglePublishLessonAction } from "@/actions/dashboard/lesson";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { DeleteLessonButton } from "../../../_components/DeleteLessonButton";
+import { PublishBadge } from "../../../_components/PublishBadge";
+
+type Props = {
+  courseId: string;
+  lesson: {
+    id: string;
+    slug: string;
+    title: string;
+    order: number;
+    isPublished: boolean;
+  };
+};
+
+export function LessonListRow({ courseId, lesson }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  const onToggle = () => {
+    startTransition(async () => {
+      await togglePublishLessonAction({
+        id: lesson.id,
+        isPublished: !lesson.isPublished,
+      });
+    });
+  };
+
+  return (
+    <Card size="sm">
+      <CardContent className="flex items-center gap-4">
+        <span className="w-10 shrink-0 font-mono text-xs text-muted-foreground">
+          #{lesson.order}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <Link
+              href={`/dashboard/courses/${courseId}/lessons/${lesson.id}`}
+              className="truncate font-medium hover:underline"
+            >
+              {lesson.title}
+            </Link>
+            <PublishBadge isPublished={lesson.isPublished} />
+          </div>
+          <p className="mt-1 truncate text-xs text-muted-foreground">/{lesson.slug}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            disabled={isPending}
+            onClick={onToggle}
+            size="sm"
+            type="button"
+            variant={lesson.isPublished ? "outline" : "default"}
+          >
+            {lesson.isPublished ? "非公開" : "公開"}
+          </Button>
+          <DeleteLessonButton lessonId={lesson.id} title={lesson.title} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(protected)/dashboard/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/src/app/(protected)/dashboard/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { requireAuth } from "@/lib/auth";
+import { ForbiddenError, NotFoundError } from "@/lib/errors";
+import { getMyCourseById } from "@/services/courseService";
+import { getMyLessonById } from "@/services/lessonService";
+import { LessonForm } from "../new/_components/LessonForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditLessonPage({
+  params,
+}: {
+  params: Promise<{ courseId: string; lessonId: string }>;
+}) {
+  const session = await requireAuth();
+  const { courseId, lessonId } = await params;
+
+  try {
+    await getMyCourseById({ id: courseId, authorId: session.userId });
+  } catch (error) {
+    if (error instanceof NotFoundError) notFound();
+    if (error instanceof ForbiddenError) throw error;
+    throw error;
+  }
+
+  let lesson: Awaited<ReturnType<typeof getMyLessonById>>;
+  try {
+    lesson = await getMyLessonById({ id: lessonId, authorId: session.userId });
+  } catch (error) {
+    if (error instanceof NotFoundError) notFound();
+    if (error instanceof ForbiddenError) throw error;
+    throw error;
+  }
+
+  if (lesson.courseId !== courseId) notFound();
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      <Link
+        href={`/dashboard/courses/${courseId}`}
+        className="text-sm text-zinc-500 hover:underline"
+      >
+        ← コース編集
+      </Link>
+      <h1 className="mt-3 mb-6 text-2xl font-bold">レッスンを編集</h1>
+      <LessonForm
+        mode="edit"
+        courseId={courseId}
+        lessonId={lesson.id}
+        initial={{
+          slug: lesson.slug,
+          title: lesson.title,
+          contentMd: lesson.contentMd,
+          starterCode: lesson.starterCode,
+          expectedOutput: lesson.expectedOutput ?? "",
+          order: String(lesson.order),
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(protected)/dashboard/courses/[courseId]/lessons/new/_components/LessonForm.tsx
+++ b/src/app/(protected)/dashboard/courses/[courseId]/lessons/new/_components/LessonForm.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { z } from "zod";
+import { createLessonAction, updateLessonAction } from "@/actions/dashboard/lesson";
+import { MonacoCodeInput } from "@/components/editor/MonacoCodeInput";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { CreateLessonSchema, UpdateLessonSchema } from "@/types/lesson";
+
+type Values = {
+  slug: string;
+  title: string;
+  contentMd: string;
+  starterCode: string;
+  expectedOutput: string;
+  order: string;
+};
+
+type Props =
+  | {
+      mode: "create";
+      courseId: string;
+      initial?: Partial<Values>;
+    }
+  | {
+      mode: "edit";
+      courseId: string;
+      lessonId: string;
+      initial: Values;
+    };
+
+type FieldKey = "slug" | "title" | "contentMd" | "starterCode" | "expectedOutput" | "order";
+
+const FIELD_KEYS: readonly FieldKey[] = [
+  "slug",
+  "title",
+  "contentMd",
+  "starterCode",
+  "expectedOutput",
+  "order",
+] as const;
+
+const emptyValues: Values = {
+  slug: "",
+  title: "",
+  contentMd: "",
+  starterCode: "",
+  expectedOutput: "",
+  order: "0",
+};
+
+export function LessonForm(props: Props) {
+  const router = useRouter();
+  const initial = props.mode === "create" ? { ...emptyValues, ...props.initial } : props.initial;
+  const [values, setValues] = useState<Values>(initial);
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<FieldKey, string>>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const setValue = <K extends keyof Values>(key: K, value: Values[K]) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    setFieldErrors({});
+
+    const orderNum = Number(values.order);
+
+    const payload = {
+      slug: values.slug,
+      title: values.title,
+      contentMd: values.contentMd,
+      starterCode: values.starterCode,
+      expectedOutput: values.expectedOutput.length === 0 ? null : values.expectedOutput,
+      order: Number.isFinite(orderNum) ? orderNum : Number.NaN,
+    };
+
+    const parsed =
+      props.mode === "create"
+        ? CreateLessonSchema.safeParse({ courseId: props.courseId, ...payload })
+        : UpdateLessonSchema.safeParse({ id: props.lessonId, ...payload });
+
+    if (!parsed.success) {
+      setFieldErrors(mapZodError(parsed.error));
+      return;
+    }
+
+    startTransition(async () => {
+      const result =
+        props.mode === "create"
+          ? await createLessonAction(parsed.data as z.infer<typeof CreateLessonSchema>)
+          : await updateLessonAction(parsed.data as z.infer<typeof UpdateLessonSchema>);
+
+      if (result?.serverError) {
+        setFormError(result.serverError);
+        return;
+      }
+      if (result?.validationErrors) {
+        setFieldErrors(extractFieldErrors(result.validationErrors));
+        return;
+      }
+      router.push(`/dashboard/courses/${props.courseId}`);
+      router.refresh();
+    });
+  };
+
+  return (
+    <form className="space-y-5" onSubmit={onSubmit}>
+      <div className="space-y-1.5">
+        <Label htmlFor="lesson-title">タイトル</Label>
+        <Input
+          id="lesson-title"
+          value={values.title}
+          onChange={(e) => setValue("title", e.target.value)}
+          aria-invalid={!!fieldErrors.title}
+        />
+        {fieldErrors.title && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.title}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="lesson-slug">slug</Label>
+        <Input
+          id="lesson-slug"
+          value={values.slug}
+          onChange={(e) => setValue("slug", e.target.value)}
+          placeholder="hello-world"
+          aria-invalid={!!fieldErrors.slug}
+        />
+        {fieldErrors.slug && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.slug}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="lesson-content">説明 (Markdown)</Label>
+        <Textarea
+          id="lesson-content"
+          rows={10}
+          value={values.contentMd}
+          onChange={(e) => setValue("contentMd", e.target.value)}
+          aria-invalid={!!fieldErrors.contentMd}
+        />
+        {fieldErrors.contentMd && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.contentMd}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="lesson-starter">スターターコード</Label>
+        <MonacoCodeInput
+          height="300px"
+          value={values.starterCode}
+          onChange={(v) => setValue("starterCode", v)}
+        />
+        {fieldErrors.starterCode && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.starterCode}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="lesson-expected">期待出力 (空欄なら判定なし)</Label>
+        <Textarea
+          id="lesson-expected"
+          rows={3}
+          value={values.expectedOutput}
+          onChange={(e) => setValue("expectedOutput", e.target.value)}
+          aria-invalid={!!fieldErrors.expectedOutput}
+        />
+        {fieldErrors.expectedOutput && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.expectedOutput}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="lesson-order">表示順</Label>
+        <Input
+          id="lesson-order"
+          type="number"
+          min={0}
+          value={values.order}
+          onChange={(e) => setValue("order", e.target.value)}
+          aria-invalid={!!fieldErrors.order}
+        />
+        {fieldErrors.order && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.order}
+          </p>
+        )}
+      </div>
+
+      {formError && (
+        <p className="text-sm text-destructive" role="alert">
+          {formError}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button disabled={isPending} onClick={() => router.back()} type="button" variant="outline">
+          キャンセル
+        </Button>
+        <Button disabled={isPending} type="submit">
+          {isPending ? "保存中..." : props.mode === "create" ? "作成" : "更新"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function mapZodError(error: z.ZodError): Partial<Record<FieldKey, string>> {
+  const result: Partial<Record<FieldKey, string>> = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (typeof key === "string" && (FIELD_KEYS as readonly string[]).includes(key)) {
+      const k = key as FieldKey;
+      if (!result[k]) result[k] = issue.message;
+    }
+  }
+  return result;
+}
+
+function extractFieldErrors(errors: unknown): Partial<Record<FieldKey, string>> {
+  const result: Partial<Record<FieldKey, string>> = {};
+  if (typeof errors !== "object" || errors === null) return result;
+  const ve = errors as Record<string, { _errors?: string[] } | undefined>;
+  for (const key of FIELD_KEYS) {
+    const msg = ve[key]?._errors?.[0];
+    if (msg) result[key] = msg;
+  }
+  return result;
+}

--- a/src/app/(protected)/dashboard/courses/[courseId]/lessons/new/_components/LessonForm.tsx
+++ b/src/app/(protected)/dashboard/courses/[courseId]/lessons/new/_components/LessonForm.tsx
@@ -160,9 +160,11 @@ export function LessonForm(props: Props) {
       </div>
 
       <div className="space-y-1.5">
-        <Label htmlFor="lesson-starter">スターターコード</Label>
+        <Label id="lesson-starter-label">スターターコード</Label>
         <MonacoCodeInput
+          ariaLabelledBy="lesson-starter-label"
           height="300px"
+          id="lesson-starter"
           value={values.starterCode}
           onChange={(v) => setValue("starterCode", v)}
         />

--- a/src/app/(protected)/dashboard/courses/[courseId]/lessons/new/page.tsx
+++ b/src/app/(protected)/dashboard/courses/[courseId]/lessons/new/page.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { requireAuth } from "@/lib/auth";
+import { ForbiddenError, NotFoundError } from "@/lib/errors";
+import { getMyCourseById } from "@/services/courseService";
+import { LessonForm } from "./_components/LessonForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewLessonPage({ params }: { params: Promise<{ courseId: string }> }) {
+  const session = await requireAuth();
+  const { courseId } = await params;
+
+  try {
+    await getMyCourseById({ id: courseId, authorId: session.userId });
+  } catch (error) {
+    if (error instanceof NotFoundError) notFound();
+    if (error instanceof ForbiddenError) throw error;
+    throw error;
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      <Link
+        href={`/dashboard/courses/${courseId}`}
+        className="text-sm text-zinc-500 hover:underline"
+      >
+        ← コース編集
+      </Link>
+      <h1 className="mt-3 mb-6 text-2xl font-bold">レッスンを追加</h1>
+      <LessonForm mode="create" courseId={courseId} />
+    </div>
+  );
+}

--- a/src/app/(protected)/dashboard/courses/[courseId]/page.tsx
+++ b/src/app/(protected)/dashboard/courses/[courseId]/page.tsx
@@ -1,0 +1,98 @@
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { buttonVariants } from "@/components/ui/button";
+import { requireAuth } from "@/lib/auth";
+import { ForbiddenError, NotFoundError } from "@/lib/errors";
+import { getMyCourseById } from "@/services/courseService";
+import { getLessonsByCourse } from "@/services/lessonService";
+import { CourseForm } from "../new/_components/CourseForm";
+import { LessonListRow } from "./_components/LessonListRow";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditCoursePage({
+  params,
+}: {
+  params: Promise<{ courseId: string }>;
+}) {
+  const session = await requireAuth();
+  const { courseId } = await params;
+
+  let course: Awaited<ReturnType<typeof getMyCourseById>>;
+  try {
+    course = await getMyCourseById({ id: courseId, authorId: session.userId });
+  } catch (error) {
+    if (error instanceof NotFoundError) notFound();
+    if (error instanceof ForbiddenError) throw error;
+    throw error;
+  }
+
+  const lessons = await getLessonsByCourse({
+    courseId: course.id,
+    authorId: session.userId,
+  });
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-10">
+      <Link href="/dashboard" className="text-sm text-zinc-500 hover:underline">
+        ← マイコース
+      </Link>
+      <h1 className="mt-3 mb-6 text-2xl font-bold">コースを編集</h1>
+
+      <section aria-labelledby="course-meta" className="mb-10">
+        <h2 id="course-meta" className="sr-only">
+          コース情報
+        </h2>
+        <CourseForm
+          mode="edit"
+          courseId={course.id}
+          initial={{
+            slug: course.slug,
+            title: course.title,
+            description: course.description,
+            order: String(course.order),
+          }}
+        />
+      </section>
+
+      <section aria-labelledby="lesson-list">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 id="lesson-list" className="text-lg font-semibold">
+            レッスン
+          </h2>
+          <Link
+            href={`/dashboard/courses/${course.id}/lessons/new`}
+            className={buttonVariants({ variant: "default", size: "sm" })}
+          >
+            <Plus aria-hidden="true" />
+            レッスン追加
+          </Link>
+        </div>
+
+        {lessons.length === 0 ? (
+          <p className="rounded-md border border-dashed border-zinc-300 p-6 text-center text-sm text-muted-foreground dark:border-zinc-700">
+            まだレッスンがありません。
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {lessons.map((l) => (
+              <li key={l.id}>
+                <LessonListRow
+                  courseId={course.id}
+                  lesson={{
+                    id: l.id,
+                    slug: l.slug,
+                    title: l.title,
+                    order: l.order,
+                    isPublished: l.isPublished,
+                  }}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(protected)/dashboard/courses/new/_components/CourseForm.tsx
+++ b/src/app/(protected)/dashboard/courses/new/_components/CourseForm.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { z } from "zod";
+import { createCourseAction, updateCourseAction } from "@/actions/dashboard/course";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { CreateCourseSchema, UpdateCourseSchema } from "@/types/course";
+
+type Values = {
+  slug: string;
+  title: string;
+  description: string;
+  order: string;
+};
+
+type Props =
+  | {
+      mode: "create";
+      initial?: Partial<Values>;
+    }
+  | {
+      mode: "edit";
+      courseId: string;
+      initial: Values;
+    };
+
+const emptyValues: Values = { slug: "", title: "", description: "", order: "0" };
+
+export function CourseForm(props: Props) {
+  const router = useRouter();
+  const initial = props.mode === "create" ? { ...emptyValues, ...props.initial } : props.initial;
+  const [values, setValues] = useState<Values>(initial);
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof Values, string>>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const setValue = <K extends keyof Values>(key: K, value: Values[K]) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    setFieldErrors({});
+
+    const orderNum = Number(values.order);
+
+    const baseInput = {
+      slug: values.slug,
+      title: values.title,
+      description: values.description,
+      order: Number.isFinite(orderNum) ? orderNum : Number.NaN,
+    };
+
+    const parsed =
+      props.mode === "create"
+        ? CreateCourseSchema.safeParse(baseInput)
+        : UpdateCourseSchema.safeParse({ id: props.courseId, ...baseInput });
+
+    if (!parsed.success) {
+      setFieldErrors(mapZodError(parsed.error));
+      return;
+    }
+
+    startTransition(async () => {
+      const result =
+        props.mode === "create"
+          ? await createCourseAction(parsed.data as z.infer<typeof CreateCourseSchema>)
+          : await updateCourseAction(parsed.data as z.infer<typeof UpdateCourseSchema>);
+
+      if (result?.serverError) {
+        setFormError(result.serverError);
+        return;
+      }
+      if (result?.validationErrors) {
+        setFieldErrors(extractFieldErrors(result.validationErrors));
+        return;
+      }
+      router.push("/dashboard");
+      router.refresh();
+    });
+  };
+
+  return (
+    <form className="space-y-5" onSubmit={onSubmit}>
+      <div className="space-y-1.5">
+        <Label htmlFor="course-title">タイトル</Label>
+        <Input
+          id="course-title"
+          value={values.title}
+          onChange={(e) => setValue("title", e.target.value)}
+          aria-invalid={!!fieldErrors.title}
+        />
+        {fieldErrors.title && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.title}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="course-slug">slug</Label>
+        <Input
+          id="course-slug"
+          value={values.slug}
+          onChange={(e) => setValue("slug", e.target.value)}
+          placeholder="ts-intro"
+          aria-invalid={!!fieldErrors.slug}
+        />
+        <p className="text-xs text-muted-foreground">
+          URL に使われます。小文字英数字とハイフンのみ。重複不可。
+        </p>
+        {fieldErrors.slug && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.slug}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="course-description">説明</Label>
+        <Textarea
+          id="course-description"
+          rows={4}
+          value={values.description}
+          onChange={(e) => setValue("description", e.target.value)}
+          aria-invalid={!!fieldErrors.description}
+        />
+        {fieldErrors.description && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.description}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="course-order">表示順</Label>
+        <Input
+          id="course-order"
+          type="number"
+          min={0}
+          value={values.order}
+          onChange={(e) => setValue("order", e.target.value)}
+          aria-invalid={!!fieldErrors.order}
+        />
+        {fieldErrors.order && (
+          <p className="text-xs text-destructive" role="alert">
+            {fieldErrors.order}
+          </p>
+        )}
+      </div>
+
+      {formError && (
+        <p className="text-sm text-destructive" role="alert">
+          {formError}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button disabled={isPending} onClick={() => router.back()} type="button" variant="outline">
+          キャンセル
+        </Button>
+        <Button disabled={isPending} type="submit">
+          {isPending ? "保存中..." : props.mode === "create" ? "作成" : "更新"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function mapZodError(error: z.ZodError): Partial<Record<keyof Values, string>> {
+  const result: Partial<Record<keyof Values, string>> = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (
+      typeof key === "string" &&
+      (key === "slug" || key === "title" || key === "description" || key === "order")
+    ) {
+      if (!result[key]) result[key] = issue.message;
+    }
+  }
+  return result;
+}
+
+type FormattedErrors = {
+  _errors?: string[];
+  [key: string]: { _errors?: string[] } | string[] | undefined;
+};
+
+function extractFieldErrors(errors: unknown): Partial<Record<keyof Values, string>> {
+  const result: Partial<Record<keyof Values, string>> = {};
+  if (typeof errors !== "object" || errors === null) return result;
+  const ve = errors as FormattedErrors;
+  for (const key of ["slug", "title", "description", "order"] as const) {
+    const entry = ve[key] as { _errors?: string[] } | undefined;
+    const msg = entry?._errors?.[0];
+    if (msg) result[key] = msg;
+  }
+  return result;
+}

--- a/src/app/(protected)/dashboard/courses/new/page.tsx
+++ b/src/app/(protected)/dashboard/courses/new/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { requireAuth } from "@/lib/auth";
+import { CourseForm } from "./_components/CourseForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewCoursePage() {
+  await requireAuth();
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-10">
+      <Link href="/dashboard" className="text-sm text-zinc-500 hover:underline">
+        ← マイコース
+      </Link>
+      <h1 className="mt-3 mb-6 text-2xl font-bold">コースを作成</h1>
+      <CourseForm mode="create" />
+    </div>
+  );
+}

--- a/src/app/(protected)/dashboard/layout.tsx
+++ b/src/app/(protected)/dashboard/layout.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { requireAuth } from "@/lib/auth";
+
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+  await requireAuth();
+
+  return (
+    <div className="flex min-h-[calc(100vh-2.5rem)] flex-1">
+      <aside className="hidden w-56 shrink-0 border-r border-zinc-200 p-4 text-sm dark:border-zinc-800 md:block">
+        <nav aria-label="ダッシュボード">
+          <h2 className="mb-3 font-semibold text-zinc-500 uppercase tracking-wide text-xs">
+            クリエイター
+          </h2>
+          <ul className="space-y-1">
+            <li>
+              <Link href="/dashboard" className="block rounded-md px-2 py-1 hover:bg-muted">
+                マイコース
+              </Link>
+            </li>
+            <li>
+              <Link href="/" className="block rounded-md px-2 py-1 hover:bg-muted">
+                学習画面へ戻る
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+      <main className="flex-1">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,0 +1,63 @@
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { requireAuth } from "@/lib/auth";
+import { getMyCourses } from "@/services/courseService";
+import { CourseListItem } from "./_components/CourseListItem";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardPage() {
+  const session = await requireAuth();
+  const courses = await getMyCourses(session.userId);
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">マイコース</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            自分が作成したコースを管理できます。公開するとすべての学習者が閲覧可能になります。
+          </p>
+        </div>
+        <Link
+          href="/dashboard/courses/new"
+          className={buttonVariants({ variant: "default", size: "sm" })}
+        >
+          <Plus aria-hidden="true" />
+          コース作成
+        </Link>
+      </header>
+
+      {courses.length === 0 ? (
+        <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-muted-foreground dark:border-zinc-700">
+          まだコースがありません。
+          <br />
+          <Link
+            className="mt-3 inline-block text-primary hover:underline"
+            href="/dashboard/courses/new"
+          >
+            最初のコースを作成する
+          </Link>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {courses.map((c) => (
+            <li key={c.id}>
+              <CourseListItem
+                course={{
+                  id: c.id,
+                  slug: c.slug,
+                  title: c.title,
+                  description: c.description,
+                  isPublished: c.isPublished,
+                  lessonCount: c.lessons.length,
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 
 export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {
@@ -7,6 +8,9 @@ export default async function ProtectedLayout({ children }: { children: React.Re
   return (
     <>
       <header className="flex items-center justify-end gap-3 border-b border-zinc-800 px-4 py-2 text-sm">
+        <Link href="/dashboard" className="mr-auto text-zinc-400 hover:text-zinc-200">
+          ダッシュボード
+        </Link>
         <span className="text-zinc-400">{displayName}</span>
         <form action="/auth/signout" method="post">
           <button

--- a/src/components/editor/MonacoCodeInput.tsx
+++ b/src/components/editor/MonacoCodeInput.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const MonacoEditor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  language?: string;
+  height?: string;
+};
+
+export function MonacoCodeInput({
+  value,
+  onChange,
+  language = "typescript",
+  height = "320px",
+}: Props) {
+  return (
+    <div className="overflow-hidden rounded-md border border-input" style={{ height }}>
+      <MonacoEditor
+        height="100%"
+        language={language}
+        theme="vs-dark"
+        value={value}
+        onChange={(v) => onChange(v ?? "")}
+        options={{
+          minimap: { enabled: false },
+          fontSize: 14,
+          scrollBeyondLastLine: false,
+          tabSize: 2,
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/MonacoCodeInput.tsx
+++ b/src/components/editor/MonacoCodeInput.tsx
@@ -9,6 +9,8 @@ type Props = {
   onChange: (value: string) => void;
   language?: string;
   height?: string;
+  id?: string;
+  ariaLabelledBy?: string;
 };
 
 export function MonacoCodeInput({
@@ -16,9 +18,18 @@ export function MonacoCodeInput({
   onChange,
   language = "typescript",
   height = "320px",
+  id,
+  ariaLabelledBy,
 }: Props) {
   return (
-    <div className="overflow-hidden rounded-md border border-input" style={{ height }}>
+    // biome-ignore lint/a11y/useSemanticElements: fieldset/legend would disrupt the Monaco wrapper layout; role=group with aria-labelledby is the documented ARIA equivalent
+    <div
+      aria-labelledby={ariaLabelledBy}
+      className="overflow-hidden rounded-md border border-input"
+      id={id}
+      role="group"
+      style={{ height }}
+    >
       <MonacoEditor
         height="100%"
         language={language}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      data-slot="input"
+      type={type}
+      className={cn(
+        "flex h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,21 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, children, ...props }: React.ComponentProps<"label">) {
+  return (
+    // biome-ignore lint/a11y/noLabelWithoutControl: callers supply htmlFor to associate with an input
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm font-medium leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </label>
+  );
+}
+
+export { Label };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/lib/safe-action.ts
+++ b/src/lib/safe-action.ts
@@ -3,10 +3,11 @@ import "server-only";
 import { createSafeActionClient, DEFAULT_SERVER_ERROR_MESSAGE } from "next-safe-action";
 import { requireAuth } from "@/lib/auth";
 import { ForbiddenError, NotFoundError, UnauthorizedError, ValidationError } from "@/lib/errors";
+import { logError } from "@/lib/logging";
 
 export const actionClient = createSafeActionClient({
   handleServerError(error) {
-    console.error("[safe-action] server error:", error);
+    logError("safeAction.handleServerError", undefined, error);
     // Let auth-class errors propagate so Next.js routes them to error.tsx /
     // the middleware redirect flow — they are not normal action failures.
     if (error instanceof UnauthorizedError) throw error;

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -9,6 +9,22 @@ export type CourseWithLessons = Prisma.CourseGetPayload<{
 
 export type CourseWithLessonIds = Course & { lessons: Pick<Lesson, "id">[] };
 
+export type CreateCourseInput = {
+  slug: string;
+  title: string;
+  description: string;
+  order: number;
+  authorId: string;
+  isPublished?: boolean;
+};
+
+export type UpdateCourseInput = {
+  slug?: string;
+  title?: string;
+  description?: string;
+  order?: number;
+};
+
 export class CourseRepository extends BaseRepository {
   async findAllWithLessonIds(): Promise<CourseWithLessonIds[]> {
     return this.client.course.findMany({
@@ -19,10 +35,85 @@ export class CourseRepository extends BaseRepository {
     });
   }
 
+  async findAllPublishedWithLessons(): Promise<CourseWithLessonIds[]> {
+    return this.client.course.findMany({
+      where: { isPublished: true },
+      orderBy: { order: "asc" },
+      include: {
+        lessons: {
+          where: { isPublished: true },
+          select: { id: true },
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+  }
+
   async findBySlugWithLessons(slug: string): Promise<CourseWithLessons | null> {
     return this.client.course.findUnique({
       where: { slug },
       include: { lessons: { orderBy: { order: "asc" } } },
+    });
+  }
+
+  async findPublishedBySlugWithPublishedLessons(slug: string): Promise<CourseWithLessons | null> {
+    return this.client.course.findFirst({
+      where: { slug, isPublished: true },
+      include: {
+        lessons: {
+          where: { isPublished: true },
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+  }
+
+  async findByAuthor(authorId: string): Promise<CourseWithLessonIds[]> {
+    return this.client.course.findMany({
+      where: { authorId },
+      orderBy: { order: "asc" },
+      include: {
+        lessons: { select: { id: true }, orderBy: { order: "asc" } },
+      },
+    });
+  }
+
+  async findById(id: string): Promise<Course | null> {
+    return this.client.course.findUnique({ where: { id } });
+  }
+
+  async findByIdForAuthor(id: string, authorId: string): Promise<Course | null> {
+    return this.client.course.findFirst({ where: { id, authorId } });
+  }
+
+  async create(input: CreateCourseInput): Promise<Course> {
+    return this.client.course.create({
+      data: {
+        slug: input.slug,
+        title: input.title,
+        description: input.description,
+        order: input.order,
+        authorId: input.authorId,
+        isPublished: input.isPublished ?? false,
+      },
+    });
+  }
+
+  async update(id: string, input: UpdateCourseInput): Promise<Course> {
+    return this.client.course.update({
+      where: { id },
+      data: input,
+    });
+  }
+
+  async delete(id: string): Promise<Course> {
+    return this.client.course.delete({ where: { id } });
+  }
+
+  async togglePublish(id: string, isPublished: boolean): Promise<Course> {
+    return this.client.course.update({
+      where: { id },
+      data: { isPublished },
     });
   }
 }

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -82,10 +82,6 @@ export class CourseRepository extends BaseRepository {
     return this.client.course.findUnique({ where: { id } });
   }
 
-  async findByIdForAuthor(id: string, authorId: string): Promise<Course | null> {
-    return this.client.course.findFirst({ where: { id, authorId } });
-  }
-
   async create(input: CreateCourseInput): Promise<Course> {
     return this.client.course.create({
       data: {

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,12 +1,20 @@
 import "server-only";
 
 import { CourseRepository } from "./course.repository";
+import { LessonRepository } from "./lesson.repository";
 import { ProfileRepository } from "./profile.repository";
 import { ProgressRepository } from "./progress.repository";
 
 export const courseRepository = new CourseRepository();
+export const lessonRepository = new LessonRepository();
 export const profileRepository = new ProfileRepository();
 export const progressRepository = new ProgressRepository();
 
-export type { CourseWithLessonIds, CourseWithLessons } from "./course.repository";
-export { CourseRepository, ProfileRepository, ProgressRepository };
+export type {
+  CourseWithLessonIds,
+  CourseWithLessons,
+  CreateCourseInput,
+  UpdateCourseInput,
+} from "./course.repository";
+export type { CreateLessonInput, UpdateLessonInput } from "./lesson.repository";
+export { CourseRepository, LessonRepository, ProfileRepository, ProgressRepository };

--- a/src/repositories/lesson.repository.ts
+++ b/src/repositories/lesson.repository.ts
@@ -42,10 +42,6 @@ export class LessonRepository extends BaseRepository {
     return this.client.lesson.findUnique({ where: { id } });
   }
 
-  async findByIdForCourse(id: string, courseId: string): Promise<Lesson | null> {
-    return this.client.lesson.findFirst({ where: { id, courseId } });
-  }
-
   async create(input: CreateLessonInput): Promise<Lesson> {
     return this.client.lesson.create({
       data: {

--- a/src/repositories/lesson.repository.ts
+++ b/src/repositories/lesson.repository.ts
@@ -1,0 +1,81 @@
+import "server-only";
+
+import type { Lesson } from "@prisma/client";
+import { BaseRepository } from "./base.repository";
+
+export type CreateLessonInput = {
+  courseId: string;
+  slug: string;
+  title: string;
+  contentMd: string;
+  starterCode: string;
+  expectedOutput: string | null;
+  order: number;
+  isPublished?: boolean;
+};
+
+export type UpdateLessonInput = {
+  slug?: string;
+  title?: string;
+  contentMd?: string;
+  starterCode?: string;
+  expectedOutput?: string | null;
+  order?: number;
+};
+
+export class LessonRepository extends BaseRepository {
+  async findByCourse(courseId: string): Promise<Lesson[]> {
+    return this.client.lesson.findMany({
+      where: { courseId },
+      orderBy: { order: "asc" },
+    });
+  }
+
+  async findPublishedByCourse(courseId: string): Promise<Lesson[]> {
+    return this.client.lesson.findMany({
+      where: { courseId, isPublished: true },
+      orderBy: { order: "asc" },
+    });
+  }
+
+  async findById(id: string): Promise<Lesson | null> {
+    return this.client.lesson.findUnique({ where: { id } });
+  }
+
+  async findByIdForCourse(id: string, courseId: string): Promise<Lesson | null> {
+    return this.client.lesson.findFirst({ where: { id, courseId } });
+  }
+
+  async create(input: CreateLessonInput): Promise<Lesson> {
+    return this.client.lesson.create({
+      data: {
+        courseId: input.courseId,
+        slug: input.slug,
+        title: input.title,
+        contentMd: input.contentMd,
+        starterCode: input.starterCode,
+        expectedOutput: input.expectedOutput,
+        order: input.order,
+        isPublished: input.isPublished ?? false,
+      },
+    });
+  }
+
+  async update(id: string, input: UpdateLessonInput): Promise<Lesson> {
+    return this.client.lesson.update({
+      where: { id },
+      data: input,
+    });
+  }
+
+  async delete(id: string): Promise<Lesson> {
+    return this.client.lesson.delete({ where: { id } });
+  }
+
+  async togglePublish(id: string, isPublished: boolean): Promise<Lesson> {
+    return this.client.lesson.update({
+      where: { id },
+      data: { isPublished },
+    });
+  }
+}

--- a/src/services/authorGuard.ts
+++ b/src/services/authorGuard.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import type { Course, Lesson } from "@prisma/client";
+import { ForbiddenError, handleUnknownError, NotFoundError } from "@/lib/errors";
+import { logError, logWarn } from "@/lib/logging";
+import {
+  type CourseRepository,
+  courseRepository,
+  type LessonRepository,
+  lessonRepository,
+} from "@/repositories";
+
+export async function ensureAuthorOwnsCourse(
+  courseId: string,
+  authorId: string,
+  repository: CourseRepository = courseRepository,
+): Promise<Course> {
+  try {
+    const course = await repository.findById(courseId);
+    if (!course) throw new NotFoundError(`Course not found: ${courseId}`);
+    if (course.authorId !== authorId) {
+      throw new ForbiddenError(`Not the author of course: ${courseId}`);
+    }
+    return course;
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      logWarn("authorGuard.ensureAuthorOwnsCourse.notFound", { courseId });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) {
+      logWarn("authorGuard.ensureAuthorOwnsCourse.forbidden", { courseId, authorId });
+      throw error;
+    }
+    logError("authorGuard.ensureAuthorOwnsCourse.error", { courseId, authorId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function ensureAuthorOwnsLesson(
+  lessonId: string,
+  authorId: string,
+  lessonRepo: LessonRepository = lessonRepository,
+  courseRepo: CourseRepository = courseRepository,
+): Promise<Lesson> {
+  try {
+    const lesson = await lessonRepo.findById(lessonId);
+    if (!lesson) throw new NotFoundError(`Lesson not found: ${lessonId}`);
+    await ensureAuthorOwnsCourse(lesson.courseId, authorId, courseRepo);
+    return lesson;
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      logWarn("authorGuard.ensureAuthorOwnsLesson.notFound", { lessonId });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) {
+      logWarn("authorGuard.ensureAuthorOwnsLesson.forbidden", { lessonId, authorId });
+      throw error;
+    }
+    logError("authorGuard.ensureAuthorOwnsLesson.error", { lessonId, authorId }, error);
+    throw handleUnknownError(error);
+  }
+}

--- a/src/services/authorGuard.ts
+++ b/src/services/authorGuard.ts
@@ -17,20 +17,17 @@ export async function ensureAuthorOwnsCourse(
 ): Promise<Course> {
   try {
     const course = await repository.findById(courseId);
-    if (!course) throw new NotFoundError(`Course not found: ${courseId}`);
+    if (!course) {
+      logWarn("authorGuard.ensureAuthorOwnsCourse.notFound", { courseId });
+      throw new NotFoundError(`Course not found: ${courseId}`);
+    }
     if (course.authorId !== authorId) {
+      logWarn("authorGuard.ensureAuthorOwnsCourse.forbidden", { courseId, authorId });
       throw new ForbiddenError(`Not the author of course: ${courseId}`);
     }
     return course;
   } catch (error) {
-    if (error instanceof NotFoundError) {
-      logWarn("authorGuard.ensureAuthorOwnsCourse.notFound", { courseId });
-      throw error;
-    }
-    if (error instanceof ForbiddenError) {
-      logWarn("authorGuard.ensureAuthorOwnsCourse.forbidden", { courseId, authorId });
-      throw error;
-    }
+    if (error instanceof NotFoundError || error instanceof ForbiddenError) throw error;
     logError("authorGuard.ensureAuthorOwnsCourse.error", { courseId, authorId }, error);
     throw handleUnknownError(error);
   }
@@ -44,18 +41,16 @@ export async function ensureAuthorOwnsLesson(
 ): Promise<Lesson> {
   try {
     const lesson = await lessonRepo.findById(lessonId);
-    if (!lesson) throw new NotFoundError(`Lesson not found: ${lessonId}`);
+    if (!lesson) {
+      logWarn("authorGuard.ensureAuthorOwnsLesson.notFound", { lessonId });
+      throw new NotFoundError(`Lesson not found: ${lessonId}`);
+    }
+    // ensureAuthorOwnsCourse already logs its own NotFoundError / ForbiddenError
+    // warnings; rethrow as-is here to avoid duplicate log lines.
     await ensureAuthorOwnsCourse(lesson.courseId, authorId, courseRepo);
     return lesson;
   } catch (error) {
-    if (error instanceof NotFoundError) {
-      logWarn("authorGuard.ensureAuthorOwnsLesson.notFound", { lessonId });
-      throw error;
-    }
-    if (error instanceof ForbiddenError) {
-      logWarn("authorGuard.ensureAuthorOwnsLesson.forbidden", { lessonId, authorId });
-      throw error;
-    }
+    if (error instanceof NotFoundError || error instanceof ForbiddenError) throw error;
     logError("authorGuard.ensureAuthorOwnsLesson.error", { lessonId, authorId }, error);
     throw handleUnknownError(error);
   }

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import type { Course } from "@prisma/client";
-import { handleUnknownError, NotFoundError, ValidationError } from "@/lib/errors";
+import { ForbiddenError, handleUnknownError, NotFoundError, ValidationError } from "@/lib/errors";
 import { logError, logInfo, logWarn } from "@/lib/logging";
 import {
   type CourseRepository,
@@ -137,6 +137,12 @@ export async function updateCourse(
       logWarn("courseService.updateCourse.slugConflict", { id, slug });
       throw new ValidationError(`Course slug already exists: ${slug}`);
     }
+    if (error instanceof NotFoundError) {
+      logWarn("courseService.updateCourse.notFound", { id });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) throw error;
+    logError("courseService.updateCourse.error", { id, authorId }, error);
     throw handleUnknownError(error);
   }
 }
@@ -152,6 +158,12 @@ export async function deleteCourse(
     await repository.delete(id);
     logInfo("courseService.deleteCourse.success", { id, authorId });
   } catch (error) {
+    if (error instanceof NotFoundError) {
+      logWarn("courseService.deleteCourse.notFound", { id });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) throw error;
+    logError("courseService.deleteCourse.error", { id, authorId }, error);
     throw handleUnknownError(error);
   }
 }
@@ -168,6 +180,12 @@ export async function togglePublishCourse(
     logInfo("courseService.togglePublishCourse.success", { id, authorId, isPublished });
     return course;
   } catch (error) {
+    if (error instanceof NotFoundError) {
+      logWarn("courseService.togglePublishCourse.notFound", { id });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) throw error;
+    logError("courseService.togglePublishCourse.error", { id, authorId }, error);
     throw handleUnknownError(error);
   }
 }

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
-import { handleUnknownError, NotFoundError } from "@/lib/errors";
+import type { Course } from "@prisma/client";
+import { handleUnknownError, NotFoundError, ValidationError } from "@/lib/errors";
 import { logError, logInfo, logWarn } from "@/lib/logging";
 import {
   type CourseRepository,
@@ -8,13 +9,14 @@ import {
   type CourseWithLessons,
   courseRepository,
 } from "@/repositories";
+import { ensureAuthorOwnsCourse } from "./authorGuard";
 
 export async function getCoursesWithLessons(
   repository: CourseRepository = courseRepository,
 ): Promise<CourseWithLessonIds[]> {
   logInfo("courseService.getCoursesWithLessons.start");
   try {
-    const result = await repository.findAllWithLessonIds();
+    const result = await repository.findAllPublishedWithLessons();
     logInfo("courseService.getCoursesWithLessons.success", { count: result.length });
     return result;
   } catch (error) {
@@ -29,7 +31,7 @@ export async function getCourseBySlug(
 ): Promise<CourseWithLessons> {
   logInfo("courseService.getCourseBySlug.start", { slug });
   try {
-    const course = await repository.findBySlugWithLessons(slug);
+    const course = await repository.findPublishedBySlugWithPublishedLessons(slug);
     if (!course) throw new NotFoundError(`Course not found: ${slug}`);
     logInfo("courseService.getCourseBySlug.success", {
       slug,
@@ -44,4 +46,139 @@ export async function getCourseBySlug(
     logError("courseService.getCourseBySlug.error", { slug }, error);
     throw handleUnknownError(error);
   }
+}
+
+export async function getMyCourses(
+  authorId: string,
+  repository: CourseRepository = courseRepository,
+): Promise<CourseWithLessonIds[]> {
+  logInfo("courseService.getMyCourses.start", { authorId });
+  try {
+    const result = await repository.findByAuthor(authorId);
+    logInfo("courseService.getMyCourses.success", { authorId, count: result.length });
+    return result;
+  } catch (error) {
+    logError("courseService.getMyCourses.error", { authorId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function getMyCourseById(
+  params: { id: string; authorId: string },
+  repository: CourseRepository = courseRepository,
+): Promise<Course> {
+  const { id, authorId } = params;
+  logInfo("courseService.getMyCourseById.start", { id, authorId });
+  try {
+    const course = await ensureAuthorOwnsCourse(id, authorId, repository);
+    logInfo("courseService.getMyCourseById.success", { id, authorId });
+    return course;
+  } catch (error) {
+    throw handleUnknownError(error);
+  }
+}
+
+export type CreateCourseParams = {
+  authorId: string;
+  slug: string;
+  title: string;
+  description: string;
+  order: number;
+};
+
+export async function createCourse(
+  params: CreateCourseParams,
+  repository: CourseRepository = courseRepository,
+): Promise<Course> {
+  const { authorId, slug, title, description, order } = params;
+  logInfo("courseService.createCourse.start", { authorId, slug });
+  try {
+    const course = await repository.create({
+      authorId,
+      slug,
+      title,
+      description,
+      order,
+    });
+    logInfo("courseService.createCourse.success", { id: course.id, authorId });
+    return course;
+  } catch (error) {
+    if (isUniqueConstraintError(error, "slug")) {
+      logWarn("courseService.createCourse.slugConflict", { slug });
+      throw new ValidationError(`Course slug already exists: ${slug}`);
+    }
+    logError("courseService.createCourse.error", { authorId, slug }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export type UpdateCourseParams = {
+  id: string;
+  authorId: string;
+  slug: string;
+  title: string;
+  description: string;
+  order: number;
+};
+
+export async function updateCourse(
+  params: UpdateCourseParams,
+  repository: CourseRepository = courseRepository,
+): Promise<Course> {
+  const { id, authorId, slug, title, description, order } = params;
+  logInfo("courseService.updateCourse.start", { id, authorId });
+  try {
+    await ensureAuthorOwnsCourse(id, authorId, repository);
+    const course = await repository.update(id, { slug, title, description, order });
+    logInfo("courseService.updateCourse.success", { id, authorId });
+    return course;
+  } catch (error) {
+    if (isUniqueConstraintError(error, "slug")) {
+      logWarn("courseService.updateCourse.slugConflict", { id, slug });
+      throw new ValidationError(`Course slug already exists: ${slug}`);
+    }
+    throw handleUnknownError(error);
+  }
+}
+
+export async function deleteCourse(
+  params: { id: string; authorId: string },
+  repository: CourseRepository = courseRepository,
+): Promise<void> {
+  const { id, authorId } = params;
+  logInfo("courseService.deleteCourse.start", { id, authorId });
+  try {
+    await ensureAuthorOwnsCourse(id, authorId, repository);
+    await repository.delete(id);
+    logInfo("courseService.deleteCourse.success", { id, authorId });
+  } catch (error) {
+    throw handleUnknownError(error);
+  }
+}
+
+export async function togglePublishCourse(
+  params: { id: string; authorId: string; isPublished: boolean },
+  repository: CourseRepository = courseRepository,
+): Promise<Course> {
+  const { id, authorId, isPublished } = params;
+  logInfo("courseService.togglePublishCourse.start", { id, authorId, isPublished });
+  try {
+    await ensureAuthorOwnsCourse(id, authorId, repository);
+    const course = await repository.togglePublish(id, isPublished);
+    logInfo("courseService.togglePublishCourse.success", { id, authorId, isPublished });
+    return course;
+  } catch (error) {
+    throw handleUnknownError(error);
+  }
+}
+
+function isUniqueConstraintError(error: unknown, field?: string): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as { code?: unknown; meta?: { target?: unknown } };
+  if (e.code !== "P2002") return false;
+  if (!field) return true;
+  const target = e.meta?.target;
+  if (Array.isArray(target)) return target.includes(field);
+  if (typeof target === "string") return target.includes(field);
+  return false;
 }

--- a/src/services/lessonService.ts
+++ b/src/services/lessonService.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import type { Lesson } from "@prisma/client";
-import { handleUnknownError, ValidationError } from "@/lib/errors";
+import { ForbiddenError, handleUnknownError, NotFoundError, ValidationError } from "@/lib/errors";
 import { logError, logInfo, logWarn } from "@/lib/logging";
 import {
   type CourseRepository,
@@ -80,10 +80,15 @@ export async function createLesson(
     logInfo("lessonService.createLesson.success", { id: lesson.id, courseId });
     return lesson;
   } catch (error) {
-    if (isUniqueConstraintError(error)) {
+    if (isUniqueConstraintError(error, "slug")) {
       logWarn("lessonService.createLesson.slugConflict", { courseId, slug });
       throw new ValidationError(`Lesson slug already exists in this course: ${slug}`);
     }
+    if (error instanceof NotFoundError) {
+      logWarn("lessonService.createLesson.notFound", { courseId });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) throw error;
     logError("lessonService.createLesson.error", { courseId, authorId, slug }, error);
     throw handleUnknownError(error);
   }
@@ -120,10 +125,16 @@ export async function updateLesson(
     logInfo("lessonService.updateLesson.success", { id, authorId });
     return lesson;
   } catch (error) {
-    if (isUniqueConstraintError(error)) {
+    if (isUniqueConstraintError(error, "slug")) {
       logWarn("lessonService.updateLesson.slugConflict", { id, slug });
       throw new ValidationError(`Lesson slug already exists in this course: ${slug}`);
     }
+    if (error instanceof NotFoundError) {
+      logWarn("lessonService.updateLesson.notFound", { id });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) throw error;
+    logError("lessonService.updateLesson.error", { id, authorId }, error);
     throw handleUnknownError(error);
   }
 }
@@ -140,6 +151,12 @@ export async function deleteLesson(
     await repository.delete(id);
     logInfo("lessonService.deleteLesson.success", { id, authorId });
   } catch (error) {
+    if (error instanceof NotFoundError) {
+      logWarn("lessonService.deleteLesson.notFound", { id });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) throw error;
+    logError("lessonService.deleteLesson.error", { id, authorId }, error);
     throw handleUnknownError(error);
   }
 }
@@ -157,12 +174,23 @@ export async function togglePublishLesson(
     logInfo("lessonService.togglePublishLesson.success", { id, authorId, isPublished });
     return lesson;
   } catch (error) {
+    if (error instanceof NotFoundError) {
+      logWarn("lessonService.togglePublishLesson.notFound", { id });
+      throw error;
+    }
+    if (error instanceof ForbiddenError) throw error;
+    logError("lessonService.togglePublishLesson.error", { id, authorId }, error);
     throw handleUnknownError(error);
   }
 }
 
-function isUniqueConstraintError(error: unknown): boolean {
+function isUniqueConstraintError(error: unknown, field?: string): boolean {
   if (typeof error !== "object" || error === null) return false;
-  const e = error as { code?: unknown };
-  return e.code === "P2002";
+  const e = error as { code?: unknown; meta?: { target?: unknown } };
+  if (e.code !== "P2002") return false;
+  if (!field) return true;
+  const target = e.meta?.target;
+  if (Array.isArray(target)) return target.includes(field);
+  if (typeof target === "string") return target.includes(field);
+  return false;
 }

--- a/src/services/lessonService.ts
+++ b/src/services/lessonService.ts
@@ -1,0 +1,168 @@
+import "server-only";
+
+import type { Lesson } from "@prisma/client";
+import { handleUnknownError, ValidationError } from "@/lib/errors";
+import { logError, logInfo, logWarn } from "@/lib/logging";
+import {
+  type CourseRepository,
+  courseRepository,
+  type LessonRepository,
+  lessonRepository,
+} from "@/repositories";
+import { ensureAuthorOwnsCourse, ensureAuthorOwnsLesson } from "./authorGuard";
+
+export async function getLessonsByCourse(
+  params: { courseId: string; authorId: string },
+  repository: LessonRepository = lessonRepository,
+  courseRepo: CourseRepository = courseRepository,
+): Promise<Lesson[]> {
+  const { courseId, authorId } = params;
+  logInfo("lessonService.getLessonsByCourse.start", { courseId, authorId });
+  try {
+    await ensureAuthorOwnsCourse(courseId, authorId, courseRepo);
+    const lessons = await repository.findByCourse(courseId);
+    logInfo("lessonService.getLessonsByCourse.success", {
+      courseId,
+      authorId,
+      count: lessons.length,
+    });
+    return lessons;
+  } catch (error) {
+    throw handleUnknownError(error);
+  }
+}
+
+export async function getMyLessonById(
+  params: { id: string; authorId: string },
+  repository: LessonRepository = lessonRepository,
+  courseRepo: CourseRepository = courseRepository,
+): Promise<Lesson> {
+  const { id, authorId } = params;
+  logInfo("lessonService.getMyLessonById.start", { id, authorId });
+  try {
+    const lesson = await ensureAuthorOwnsLesson(id, authorId, repository, courseRepo);
+    logInfo("lessonService.getMyLessonById.success", { id, authorId });
+    return lesson;
+  } catch (error) {
+    throw handleUnknownError(error);
+  }
+}
+
+export type CreateLessonParams = {
+  courseId: string;
+  authorId: string;
+  slug: string;
+  title: string;
+  contentMd: string;
+  starterCode: string;
+  expectedOutput: string | null;
+  order: number;
+};
+
+export async function createLesson(
+  params: CreateLessonParams,
+  repository: LessonRepository = lessonRepository,
+  courseRepo: CourseRepository = courseRepository,
+): Promise<Lesson> {
+  const { courseId, authorId, slug, title, contentMd, starterCode, expectedOutput, order } = params;
+  logInfo("lessonService.createLesson.start", { courseId, authorId, slug });
+  try {
+    await ensureAuthorOwnsCourse(courseId, authorId, courseRepo);
+    const lesson = await repository.create({
+      courseId,
+      slug,
+      title,
+      contentMd,
+      starterCode,
+      expectedOutput,
+      order,
+    });
+    logInfo("lessonService.createLesson.success", { id: lesson.id, courseId });
+    return lesson;
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      logWarn("lessonService.createLesson.slugConflict", { courseId, slug });
+      throw new ValidationError(`Lesson slug already exists in this course: ${slug}`);
+    }
+    logError("lessonService.createLesson.error", { courseId, authorId, slug }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export type UpdateLessonParams = {
+  id: string;
+  authorId: string;
+  slug: string;
+  title: string;
+  contentMd: string;
+  starterCode: string;
+  expectedOutput: string | null;
+  order: number;
+};
+
+export async function updateLesson(
+  params: UpdateLessonParams,
+  repository: LessonRepository = lessonRepository,
+  courseRepo: CourseRepository = courseRepository,
+): Promise<Lesson> {
+  const { id, authorId, slug, title, contentMd, starterCode, expectedOutput, order } = params;
+  logInfo("lessonService.updateLesson.start", { id, authorId });
+  try {
+    await ensureAuthorOwnsLesson(id, authorId, repository, courseRepo);
+    const lesson = await repository.update(id, {
+      slug,
+      title,
+      contentMd,
+      starterCode,
+      expectedOutput,
+      order,
+    });
+    logInfo("lessonService.updateLesson.success", { id, authorId });
+    return lesson;
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      logWarn("lessonService.updateLesson.slugConflict", { id, slug });
+      throw new ValidationError(`Lesson slug already exists in this course: ${slug}`);
+    }
+    throw handleUnknownError(error);
+  }
+}
+
+export async function deleteLesson(
+  params: { id: string; authorId: string },
+  repository: LessonRepository = lessonRepository,
+  courseRepo: CourseRepository = courseRepository,
+): Promise<void> {
+  const { id, authorId } = params;
+  logInfo("lessonService.deleteLesson.start", { id, authorId });
+  try {
+    await ensureAuthorOwnsLesson(id, authorId, repository, courseRepo);
+    await repository.delete(id);
+    logInfo("lessonService.deleteLesson.success", { id, authorId });
+  } catch (error) {
+    throw handleUnknownError(error);
+  }
+}
+
+export async function togglePublishLesson(
+  params: { id: string; authorId: string; isPublished: boolean },
+  repository: LessonRepository = lessonRepository,
+  courseRepo: CourseRepository = courseRepository,
+): Promise<Lesson> {
+  const { id, authorId, isPublished } = params;
+  logInfo("lessonService.togglePublishLesson.start", { id, authorId, isPublished });
+  try {
+    await ensureAuthorOwnsLesson(id, authorId, repository, courseRepo);
+    const lesson = await repository.togglePublish(id, isPublished);
+    logInfo("lessonService.togglePublishLesson.success", { id, authorId, isPublished });
+    return lesson;
+  } catch (error) {
+    throw handleUnknownError(error);
+  }
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as { code?: unknown };
+  return e.code === "P2002";
+}

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+export const CourseSlugSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9-]*$/, "slug は小文字英数字とハイフンのみ");
+
+export const CreateCourseSchema = z.object({
+  slug: CourseSlugSchema,
+  title: z.string().min(1).max(120),
+  description: z.string().min(1).max(2000),
+  order: z.number().int().min(0).max(10_000),
+});
+
+export const UpdateCourseSchema = z.object({
+  id: z.cuid(),
+  slug: CourseSlugSchema,
+  title: z.string().min(1).max(120),
+  description: z.string().min(1).max(2000),
+  order: z.number().int().min(0).max(10_000),
+});
+
+export const DeleteCourseSchema = z.object({
+  id: z.cuid(),
+});
+
+export const TogglePublishCourseSchema = z.object({
+  id: z.cuid(),
+  isPublished: z.boolean(),
+});
+
+export type CreateCourseInput = z.infer<typeof CreateCourseSchema>;
+export type UpdateCourseInput = z.infer<typeof UpdateCourseSchema>;

--- a/src/types/lesson.ts
+++ b/src/types/lesson.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const LessonSlugSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9-]*$/, "slug は小文字英数字とハイフンのみ");
+
+const LessonBaseFields = {
+  slug: LessonSlugSchema,
+  title: z.string().min(1).max(120),
+  contentMd: z.string().min(1).max(50_000),
+  starterCode: z.string().max(50_000),
+  expectedOutput: z.string().max(10_000).nullable(),
+  order: z.number().int().min(0).max(10_000),
+} as const;
+
+export const CreateLessonSchema = z.object({
+  courseId: z.cuid(),
+  ...LessonBaseFields,
+});
+
+export const UpdateLessonSchema = z.object({
+  id: z.cuid(),
+  ...LessonBaseFields,
+});
+
+export const DeleteLessonSchema = z.object({
+  id: z.cuid(),
+});
+
+export const TogglePublishLessonSchema = z.object({
+  id: z.cuid(),
+  isPublished: z.boolean(),
+});
+
+export type CreateLessonInput = z.infer<typeof CreateLessonSchema>;
+export type UpdateLessonInput = z.infer<typeof UpdateLessonSchema>;


### PR DESCRIPTION
## Summary

Issue #26 の UGC 化フェーズ 1。ログインユーザーが自分のコース／レッスンを作成・編集・公開できる最小セットを入れる。

- `Course.authorId` / `Course.isPublished` / `Lesson.isPublished` を追加（migration 込み）
- `CourseRepository` 拡張 + `LessonRepository` 新設（Prisma は repository 以下でのみ使用）
- Service 層に create/update/delete/togglePublish と `authorGuard.ts`（`ensureAuthorOwnsCourse` / `ensureAuthorOwnsLesson`）
- Server Actions (`next-safe-action` + Zod) を `src/actions/dashboard/{course,lesson}.ts` に分離
- `/dashboard` ルートツリー（layout / 一覧 / Course form / Lesson form + Monaco）
- learner view を `isPublished=true` のコース／レッスンのみ返すように
- `MonacoCodeInput` を form 再利用向けに抽出
- `.claude/rules/architecture.md` にダッシュボード配置と authorId 認可パターンを追記

## フェーズ 2 以降に残す項目

- 他ユーザーのコース探索（ブラウズ UI）、いいね、コメント
- ADMIN ロールによる運用モデレーション
- RHF + `@hookform/resolvers/zod` への置換（現状は `useState` + `safeParse` 最小構成）
- リッチ Markdown エディタ / プレビュー
- 過去データの authorId バックフィル（現在は `null` = 匿名投稿扱い）

## マージ後の手動タスク

- 本番 Supabase DB には `prisma migrate deploy` を実行（`20260424105831_add_ugc_fields_to_course_lesson`）
- dev 環境では migrate 適用済みと想定

## Test plan

- [ ] `npm run db:up` → `npm run db:migrate:status` で新規 migration が pending になっていること
- [ ] `npm run db:seed` で既存コースが `isPublished=true` で再シードされる
- [ ] `npm run dev` で `/dashboard` に遷移し、自分のコース一覧が空→「コース作成」リンク表示
- [ ] `/dashboard/courses/new` から Course 作成後、一覧に `非公開` バッジ付きで表示される
- [ ] コース詳細で Lesson を追加、Monaco で starterCode が編集できる
- [ ] コース／レッスンの「公開する」トグルで `/` （learner view）に反映される
- [ ] 他ユーザーが author の courseId を `/dashboard/courses/...` で開くと `error.tsx`（ForbiddenError）に伝播する
- [ ] slug 重複時は `validationError` が form 側で field error として表示される
- [ ] `npx tsc --noEmit` / `npm run check` / `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)