### PR TITLE
feat(ui): codeMaker デザイン適用 (UI 全面刷新)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# codelearn
+# codeMaker (codelearn)
 
-Progate 風の TypeScript 学習プラットフォーム。ブラウザ上のエディタで TypeScript を書き、**そのままブラウザ内で transpile / 実行**して結果を期待出力と突き合わせる。
+**codeMaker** (internal repo 名: `codelearn`) は Progate 風の TypeScript 学習プラットフォーム。ブラウザ上のエディタで TypeScript を書き、**そのままブラウザ内で transpile / 実行**して結果を期待出力と突き合わせる。
+
+> UI 上のブランド名は **codeMaker**。リポジトリ名・npm package 名は歴史的経緯で `codelearn` のまま。
 
 ## 技術スタック
 

--- a/src/app/(protected)/_components/TopBar.tsx
+++ b/src/app/(protected)/_components/TopBar.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Bell, BookOpen, Compass, Plus, Search } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  displayName: string;
+  avatarInitial: string;
+};
+
+type NavGroup = "learn" | "explore" | "create" | null;
+
+function resolveNavGroup(pathname: string): NavGroup {
+  if (pathname.startsWith("/dashboard")) return "create";
+  if (pathname.startsWith("/explore")) return "explore";
+  if (pathname === "/" || pathname.startsWith("/courses") || pathname.startsWith("/me")) {
+    return "learn";
+  }
+  return null;
+}
+
+export function TopBar({ displayName, avatarInitial }: Props) {
+  const pathname = usePathname();
+  const group = resolveNavGroup(pathname);
+
+  return (
+    <header
+      className="sticky top-0 z-50 grid items-center gap-6 border-b px-6 py-3 backdrop-blur"
+      style={{
+        gridTemplateColumns: "240px 1fr auto",
+        background: "oklch(0.18 0.008 280 / 0.85)",
+        borderColor: "var(--line-1)",
+      }}
+    >
+      <Link
+        href="/"
+        className="flex items-center gap-2.5 font-bold text-[15px] tracking-tight"
+        aria-label="codeMaker ホーム"
+      >
+        <span className="cm-brand-mark" aria-hidden="true">
+          {"</>"}
+        </span>
+        <span>codeMaker</span>
+        <span
+          className="ml-0.5 font-mono font-normal text-[11px]"
+          style={{ color: "var(--text-3)" }}
+        >
+          beta
+        </span>
+      </Link>
+
+      <div className="relative mx-auto w-full max-w-[520px]">
+        <Search
+          aria-hidden="true"
+          className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-3.5"
+          style={{ color: "var(--text-3)" }}
+        />
+        <input
+          type="search"
+          placeholder="コース / レッスンを検索…"
+          aria-label="検索"
+          className="w-full rounded-[10px] py-[9px] pr-16 pl-10 text-[13px] outline-none transition"
+          style={{
+            background: "var(--bg-1)",
+            border: "1px solid var(--line-2)",
+            color: "var(--text-1)",
+          }}
+        />
+        <span className="-translate-y-1/2 absolute top-1/2 right-2.5 flex gap-1">
+          <span className="cm-kbd">⌘</span>
+          <span className="cm-kbd">K</span>
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <nav
+          aria-label="主要ナビゲーション"
+          className="flex gap-0.5 rounded-[10px] p-[3px]"
+          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+        >
+          <NavTab
+            href="/explore"
+            active={group === "explore"}
+            icon={<Compass className="size-3.5" />}
+          >
+            探す
+          </NavTab>
+          <NavTab href="/" active={group === "learn"} icon={<BookOpen className="size-3.5" />}>
+            学ぶ
+          </NavTab>
+          <NavTab
+            href="/dashboard"
+            active={group === "create"}
+            icon={<Plus className="size-3.5" />}
+          >
+            作る
+          </NavTab>
+        </nav>
+        <button
+          type="button"
+          aria-label="通知"
+          className="relative grid size-9 place-items-center rounded-[10px] transition"
+          style={{ color: "var(--text-2)" }}
+        >
+          <Bell className="size-[18px]" />
+          <span
+            className="absolute top-2 right-2 size-2 rounded-full"
+            style={{ background: "var(--accent-solid)", border: "2px solid var(--bg-0)" }}
+          />
+        </button>
+        <Link
+          href="/me"
+          className="cm-avatar"
+          aria-label={`${displayName} のプロフィール`}
+          title={displayName}
+        >
+          {avatarInitial}
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function NavTab({
+  href,
+  active,
+  icon,
+  children,
+}: {
+  href: string;
+  active: boolean;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-[6px] px-3.5 py-1.5 font-medium text-[13px] transition",
+      )}
+      style={{
+        color: active ? "var(--text-1)" : "var(--text-3)",
+        background: active ? "var(--bg-3)" : "transparent",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex"
+        style={{ color: active ? "var(--accent-solid)" : undefined }}
+      >
+        {icon}
+      </span>
+      {children}
+    </Link>
+  );
+}

--- a/src/app/(protected)/_components/TopBar.tsx
+++ b/src/app/(protected)/_components/TopBar.tsx
@@ -59,9 +59,10 @@ export function TopBar({ displayName, avatarInitial }: Props) {
         />
         <input
           type="search"
-          placeholder="コース / レッスンを検索…"
-          aria-label="検索"
-          className="w-full rounded-[10px] py-[9px] pr-16 pl-10 text-[13px] outline-none transition"
+          disabled
+          placeholder="検索 (近日公開)"
+          aria-label="検索 (近日公開)"
+          className="w-full cursor-not-allowed rounded-[10px] py-[9px] pr-16 pl-10 text-[13px] outline-none transition"
           style={{
             background: "var(--bg-1)",
             border: "1px solid var(--line-2)",

--- a/src/app/(protected)/_components/TopBarSwitcher.tsx
+++ b/src/app/(protected)/_components/TopBarSwitcher.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { TopBar } from "./TopBar";
+
+type Props = {
+  displayName: string;
+  avatarInitial: string;
+};
+
+export function TopBarSwitcher(props: Props) {
+  const pathname = usePathname();
+  // Lesson page renders its own ProblemTopBar in LessonClient (full-bleed layout).
+  const isFullBleed = /^\/courses\/[^/]+\/lessons\/[^/]+\/?$/.test(pathname);
+  if (isFullBleed) return null;
+  return <TopBar {...props} />;
+}

--- a/src/app/(protected)/_components/TopBarSwitcher.tsx
+++ b/src/app/(protected)/_components/TopBarSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { useSelectedLayoutSegments } from "next/navigation";
 import { TopBar } from "./TopBar";
 
 type Props = {
@@ -9,9 +9,10 @@ type Props = {
 };
 
 export function TopBarSwitcher(props: Props) {
-  const pathname = usePathname();
-  // Lesson page renders its own ProblemTopBar in LessonClient (full-bleed layout).
-  const isFullBleed = /^\/courses\/[^/]+\/lessons\/[^/]+\/?$/.test(pathname);
+  // Segments are relative to (protected)/layout.tsx. A lesson page resolves to
+  // ["courses", "<slug>", "lessons", "<lessonSlug>"] — render its own full-bleed header.
+  const segments = useSelectedLayoutSegments();
+  const isFullBleed = segments[0] === "courses" && segments[2] === "lessons";
   if (isFullBleed) return null;
   return <TopBar {...props} />;
 }

--- a/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
+++ b/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
@@ -165,8 +165,12 @@ export default function LessonClient({
                     </h3>
                   ),
                   p: ({ children }) => <p className="mb-3 leading-7 text-[13.5px]">{children}</p>,
-                  code: ({ className, children }) => {
-                    const isInline = !className;
+                  code: ({ className, children, ...rest }) => {
+                    // react-markdown v10+ no longer passes an `inline` prop. Treat a single
+                    // text node without a language class as inline; anything structural
+                    // (multi-line content, nested nodes) is a fenced block.
+                    const isInline =
+                      !className && typeof children === "string" && !children.includes("\n");
                     return isInline ? (
                       <code
                         className="rounded px-1.5 py-0.5 font-mono text-[0.9em]"
@@ -179,7 +183,9 @@ export default function LessonClient({
                         {children}
                       </code>
                     ) : (
-                      <code className={className}>{children}</code>
+                      <code className={className} {...rest}>
+                        {children}
+                      </code>
                     );
                   },
                   pre: ({ children }) => (
@@ -201,7 +207,13 @@ export default function LessonClient({
                     <ol className="mb-3 list-decimal space-y-1 pl-5">{children}</ol>
                   ),
                   a: ({ href, children }) => (
-                    <a href={href} className="underline" style={{ color: "var(--accent-solid)" }}>
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                      style={{ color: "var(--accent-solid)" }}
+                    >
                       {children}
                     </a>
                   ),

--- a/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
+++ b/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { Check } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  ChevronRight,
+  FileText,
+  Play,
+  RotateCcw,
+  X,
+} from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { useLessonRunner } from "../_hooks/useLessonRunner";
 
 const MonacoEditor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
@@ -44,161 +52,466 @@ export default function LessonClient({
     initiallyCompleted,
   });
 
+  const passed =
+    completed ||
+    (!!output &&
+      !output.stderr &&
+      !output.timedOut &&
+      output.exitCode === 0 &&
+      lesson.expectedOutput !== null &&
+      output.stdout.trim() === lesson.expectedOutput.trim());
+
   return (
-    <div className="flex h-screen flex-1 flex-col">
-      <header className="flex items-center gap-4 border-b border-zinc-200 px-6 py-3 dark:border-zinc-800">
-        <Link href={`/courses/${courseSlug}`} className="text-sm text-zinc-500 hover:underline">
-          ← {courseTitle}
-        </Link>
-        <h1 className="text-lg font-semibold">{lesson.title}</h1>
-        {completed && (
-          <Badge
-            className="ml-auto bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
-            variant="secondary"
+    <div
+      className="flex h-screen flex-col"
+      style={{ background: "var(--bg-0)", color: "var(--text-1)" }}
+    >
+      {/* Problem top bar */}
+      <header
+        className="grid items-center gap-4 border-b px-5 py-2.5"
+        style={{
+          gridTemplateColumns: "1fr auto 1fr",
+          borderColor: "var(--line-1)",
+          background: "var(--bg-0)",
+        }}
+      >
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/courses/${courseSlug}`}
+            className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
+            style={{ color: "var(--text-2)" }}
           >
-            <Check aria-hidden="true" />
-            クリア済み
-          </Badge>
-        )}
+            <ArrowLeft className="size-3.5" aria-hidden="true" /> コース
+          </Link>
+          <div className="flex items-center gap-1.5 text-[12px]" style={{ color: "var(--text-3)" }}>
+            <span>{courseTitle}</span>
+            <ChevronRight className="size-3" aria-hidden="true" />
+            <b style={{ color: "var(--text-1)", fontWeight: 500 }}>レッスン</b>
+          </div>
+        </div>
+        <div className="text-center">
+          <h1 className="m-0 font-semibold text-[15px] tracking-tight">{lesson.title}</h1>
+          <div className="mt-0.5 font-mono text-[11px]" style={{ color: "var(--text-4)" }}>
+            #{lesson.slug} · <span className="cm-diff-badge cm-diff-1 align-middle">初級</span>
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          {passed ? (
+            <span
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 font-semibold text-[11px]"
+              style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
+            >
+              <Check className="size-3" aria-hidden="true" /> クリア済み
+            </span>
+          ) : null}
+        </div>
       </header>
 
-      <div className="flex flex-1 overflow-hidden">
-        <aside className="w-1/2 overflow-y-auto border-r border-zinc-200 p-8 dark:border-zinc-800">
-          <div className="mx-auto max-w-prose">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                h1: ({ children }) => <h1 className="mb-5 mt-2 text-3xl font-bold">{children}</h1>,
-                h2: ({ children }) => (
-                  <h2 className="mb-3 mt-8 text-xl font-semibold">{children}</h2>
-                ),
-                h3: ({ children }) => (
-                  <h3 className="mb-2 mt-6 text-base font-semibold">{children}</h3>
-                ),
-                p: ({ children }) => (
-                  <p className="mb-4 leading-7 text-zinc-700 dark:text-zinc-300">{children}</p>
-                ),
-                code: ({ className, children }) => {
-                  const isInline = !className;
-                  return isInline ? (
-                    <code className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[0.9em] text-pink-600 dark:bg-zinc-800 dark:text-pink-400">
+      {/* Split pane */}
+      <div
+        className="grid overflow-hidden"
+        style={{
+          gridTemplateColumns: "minmax(280px, 1fr) minmax(420px, 1.2fr)",
+          flex: 1,
+        }}
+      >
+        {/* LEFT: problem statement */}
+        <div
+          className="flex flex-col overflow-hidden border-r"
+          style={{ borderColor: "var(--line-1)", minWidth: 0 }}
+        >
+          <div
+            className="flex flex-shrink-0 items-center gap-0.5 border-b px-3 py-1.5"
+            style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
+          >
+            <div
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1.5 font-medium text-[12px]"
+              style={{
+                color: "var(--text-1)",
+                background: "var(--bg-2)",
+                boxShadow: "inset 0 -2px 0 var(--accent-solid)",
+              }}
+            >
+              <FileText className="size-3.5" aria-hidden="true" /> 問題
+            </div>
+          </div>
+          <div className="flex-1 overflow-auto px-6 py-5">
+            <div className="mx-auto max-w-[720px]" style={{ color: "var(--text-2)" }}>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  h1: ({ children }) => (
+                    <h1
+                      className="mt-1 mb-4 font-bold text-[22px] tracking-tight"
+                      style={{ color: "var(--text-1)" }}
+                    >
                       {children}
-                    </code>
-                  ) : (
-                    <code className={className}>{children}</code>
-                  );
-                },
-                pre: ({ children }) => (
-                  <pre className="mb-4 overflow-x-auto rounded-md bg-zinc-900 p-4 text-sm text-zinc-100">
-                    {children}
-                  </pre>
-                ),
-                ul: ({ children }) => (
-                  <ul className="mb-4 list-disc space-y-1 pl-6 text-zinc-700 dark:text-zinc-300">
-                    {children}
-                  </ul>
-                ),
-                ol: ({ children }) => (
-                  <ol className="mb-4 list-decimal space-y-1 pl-6 text-zinc-700 dark:text-zinc-300">
-                    {children}
-                  </ol>
-                ),
-                a: ({ href, children }) => (
-                  <a href={href} className="text-blue-600 hover:underline">
-                    {children}
-                  </a>
-                ),
-                strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-              }}
-            >
-              {lesson.contentMd}
-            </ReactMarkdown>
-          </div>
-        </aside>
-
-        <main className="flex w-1/2 flex-col">
-          <div className="flex items-center gap-2 border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
-            <Button
-              className="bg-emerald-600 text-white hover:bg-emerald-700"
-              disabled={running}
-              onClick={run}
-              size="sm"
-              type="button"
-            >
-              {running ? "実行中..." : "▶ 実行"}
-            </Button>
-            <Button onClick={reset} size="sm" type="button" variant="outline">
-              リセット
-            </Button>
-            {lesson.expectedOutput && (
-              <span className="ml-2 text-xs text-zinc-500">期待出力と一致すればクリア</span>
-            )}
-          </div>
-
-          <div className="flex-1">
-            <MonacoEditor
-              height="100%"
-              language="typescript"
-              theme="vs-dark"
-              value={code}
-              onChange={(v) => setCode(v ?? "")}
-              options={{
-                minimap: { enabled: false },
-                fontSize: 14,
-                scrollBeyondLastLine: false,
-                tabSize: 2,
-                fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-              }}
-            />
-          </div>
-
-          <div className="h-48 shrink-0 overflow-auto border-t border-zinc-200 bg-zinc-50 p-3 font-mono text-sm dark:border-zinc-800 dark:bg-zinc-950">
-            {output ? (
-              <>
-                {output.stdout && (
-                  <pre className="whitespace-pre-wrap text-zinc-800 dark:text-zinc-100">
-                    {output.stdout}
-                  </pre>
-                )}
-                {output.stderr && (
-                  <pre className="whitespace-pre-wrap text-red-600 dark:text-red-400">
-                    {output.stderr}
-                  </pre>
-                )}
-                {output.timedOut && <p className="text-amber-600">⏱ タイムアウト (5s)</p>}
-                {!output.stdout && !output.stderr && !output.timedOut && (
-                  <p className="text-zinc-500">(出力なし)</p>
-                )}
-              </>
-            ) : (
-              <p className="text-zinc-500">実行するとここに結果が表示されます</p>
-            )}
-          </div>
-
-          <nav className="flex shrink-0 items-center justify-between border-t border-zinc-200 p-3 dark:border-zinc-800">
-            {prevSlug ? (
-              <Link
-                href={`/courses/${courseSlug}/lessons/${prevSlug}`}
-                className="text-sm text-zinc-600 hover:underline dark:text-zinc-300"
+                    </h1>
+                  ),
+                  h2: ({ children }) => (
+                    <h2
+                      className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
+                      style={{ color: "var(--text-1)" }}
+                    >
+                      {children}
+                    </h2>
+                  ),
+                  h3: ({ children }) => (
+                    <h3
+                      className="mt-5 mb-2 font-semibold text-[14px]"
+                      style={{ color: "var(--text-1)" }}
+                    >
+                      {children}
+                    </h3>
+                  ),
+                  p: ({ children }) => <p className="mb-3 leading-7 text-[13.5px]">{children}</p>,
+                  code: ({ className, children }) => {
+                    const isInline = !className;
+                    return isInline ? (
+                      <code
+                        className="rounded px-1.5 py-0.5 font-mono text-[0.9em]"
+                        style={{
+                          background: "var(--bg-2)",
+                          color: "var(--accent-solid)",
+                          border: "1px solid var(--line-1)",
+                        }}
+                      >
+                        {children}
+                      </code>
+                    ) : (
+                      <code className={className}>{children}</code>
+                    );
+                  },
+                  pre: ({ children }) => (
+                    <pre
+                      className="mb-4 overflow-x-auto rounded-[10px] p-3 font-mono text-[12.5px] leading-relaxed"
+                      style={{
+                        background: "var(--bg-code)",
+                        border: "1px solid var(--line-1)",
+                        color: "var(--text-1)",
+                      }}
+                    >
+                      {children}
+                    </pre>
+                  ),
+                  ul: ({ children }) => (
+                    <ul className="mb-3 list-disc space-y-1 pl-5">{children}</ul>
+                  ),
+                  ol: ({ children }) => (
+                    <ol className="mb-3 list-decimal space-y-1 pl-5">{children}</ol>
+                  ),
+                  a: ({ href, children }) => (
+                    <a href={href} className="underline" style={{ color: "var(--accent-solid)" }}>
+                      {children}
+                    </a>
+                  ),
+                  strong: ({ children }) => (
+                    <strong className="font-semibold" style={{ color: "var(--text-1)" }}>
+                      {children}
+                    </strong>
+                  ),
+                }}
               >
-                ← 前のレッスン
-              </Link>
-            ) : (
-              <span />
-            )}
-            {nextSlug ? (
-              <Link
-                href={`/courses/${courseSlug}/lessons/${nextSlug}`}
-                className="text-sm text-zinc-600 hover:underline dark:text-zinc-300"
+                {lesson.contentMd}
+              </ReactMarkdown>
+
+              {lesson.expectedOutput ? (
+                <section className="mt-6">
+                  <h2
+                    className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
+                    style={{ color: "var(--text-1)" }}
+                  >
+                    期待される出力
+                  </h2>
+                  <div
+                    className="overflow-hidden rounded-[10px]"
+                    style={{
+                      background: "var(--bg-1)",
+                      border: "1px solid var(--line-1)",
+                    }}
+                  >
+                    <div
+                      className="border-b px-3 py-2 font-mono text-[11px]"
+                      style={{
+                        borderColor: "var(--line-1)",
+                        background: "var(--bg-2)",
+                        color: "var(--text-3)",
+                      }}
+                    >
+                      Expected stdout
+                    </div>
+                    <pre
+                      className="m-0 p-3 font-mono text-[12.5px] leading-relaxed"
+                      style={{ background: "var(--bg-code)", color: "var(--text-1)" }}
+                    >
+                      {lesson.expectedOutput}
+                    </pre>
+                  </div>
+                </section>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT: editor + results */}
+        <div
+          className="grid overflow-hidden"
+          style={{
+            gridTemplateRows: "1fr 240px",
+            background: "var(--bg-code)",
+            minWidth: 0,
+          }}
+        >
+          {/* Editor */}
+          <div className="flex flex-col overflow-hidden">
+            <div
+              className="flex flex-shrink-0 items-center justify-between border-b px-2.5 py-1.5"
+              style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
+            >
+              <div
+                className="flex items-center gap-2 text-[12px]"
+                style={{ color: "var(--text-3)" }}
               >
-                次のレッスン →
-              </Link>
-            ) : (
-              <span />
-            )}
-          </nav>
-        </main>
+                <span
+                  className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
+                  style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}
+                >
+                  TypeScript
+                </span>
+                <span className="font-mono">main.ts</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={reset}
+                  className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-[12px] transition hover:bg-[var(--bg-2)]"
+                  style={{ color: "var(--text-2)" }}
+                >
+                  <RotateCcw className="size-3" aria-hidden="true" /> リセット
+                </button>
+              </div>
+            </div>
+            <div className="relative flex-1" style={{ background: "var(--bg-code)" }}>
+              <MonacoEditor
+                height="100%"
+                language="typescript"
+                theme="vs-dark"
+                value={code}
+                onChange={(v) => setCode(v ?? "")}
+                options={{
+                  minimap: { enabled: false },
+                  fontSize: 13.5,
+                  lineHeight: 22,
+                  scrollBeyondLastLine: false,
+                  smoothScrolling: true,
+                  padding: { top: 12, bottom: 12 },
+                  tabSize: 2,
+                  fontFamily: "var(--font-mono-family)",
+                  fontLigatures: true,
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Results */}
+          <div
+            className="flex flex-col overflow-hidden border-t"
+            style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
+          >
+            <div
+              className="flex flex-shrink-0 items-center justify-between gap-2 border-b px-3 py-1.5"
+              style={{ borderColor: "var(--line-1)" }}
+            >
+              <div
+                className="inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1.5 font-medium text-[12px]"
+                style={{
+                  color: "var(--text-1)",
+                  background: "var(--bg-2)",
+                  boxShadow: "inset 0 -2px 0 var(--accent-solid)",
+                }}
+              >
+                <Play className="size-3" aria-hidden="true" /> 実行結果
+              </div>
+              {running ? (
+                <span
+                  className="cm-pulse inline-flex items-center gap-1.5 font-mono text-[11px]"
+                  style={{ color: "var(--text-3)" }}
+                >
+                  ● 実行中…
+                </span>
+              ) : null}
+            </div>
+            <div
+              className="flex-1 overflow-auto p-4 font-mono text-[12px]"
+              style={{ color: "var(--text-1)" }}
+            >
+              <ResultBody output={output} expected={lesson.expectedOutput} passed={passed} />
+            </div>
+          </div>
+        </div>
       </div>
+
+      {/* Bottom bar */}
+      <footer
+        className="grid items-center gap-4 border-t px-5 py-2.5"
+        style={{ gridTemplateColumns: "1fr auto 1fr", borderColor: "var(--line-1)" }}
+      >
+        <div className="flex gap-2">
+          {prevSlug ? (
+            <Link
+              href={`/courses/${courseSlug}/lessons/${prevSlug}`}
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
+              style={{
+                background: "var(--bg-2)",
+                border: "1px solid var(--line-2)",
+                color: "var(--text-1)",
+              }}
+            >
+              <ArrowLeft className="size-3.5" aria-hidden="true" /> 前のレッスン
+            </Link>
+          ) : (
+            <span />
+          )}
+          {nextSlug ? (
+            <Link
+              href={`/courses/${courseSlug}/lessons/${nextSlug}`}
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
+              style={{
+                background: "var(--bg-2)",
+                border: "1px solid var(--line-2)",
+                color: "var(--text-1)",
+              }}
+            >
+              次のレッスン <ArrowRight className="size-3.5" aria-hidden="true" />
+            </Link>
+          ) : null}
+        </div>
+        <div
+          className="flex items-center gap-1.5 font-mono text-[11px]"
+          style={{ color: "var(--text-3)" }}
+        >
+          {lesson.expectedOutput ? "期待出力と一致すればクリア" : "実行して動作を確認しよう"}
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            disabled={running}
+            onClick={run}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-[10px] px-4 py-1.5 font-semibold text-[13px] transition",
+              running ? "cursor-not-allowed opacity-60" : "",
+            )}
+            style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
+          >
+            <Play className="size-3.5" aria-hidden="true" />
+            {running ? "実行中…" : "実行"}
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function ResultBody({
+  output,
+  expected,
+  passed,
+}: {
+  output: ReturnType<typeof useLessonRunner>["output"];
+  expected: string | null;
+  passed: boolean;
+}) {
+  if (!output) {
+    return (
+      <div className="py-10 text-center font-sans text-[13px]" style={{ color: "var(--text-3)" }}>
+        実行するとここに結果が表示されます
+      </div>
+    );
+  }
+
+  const hasStderr = !!output.stderr;
+  const hasStdout = !!output.stdout;
+
+  return (
+    <div className="space-y-3">
+      {expected !== null ? (
+        <div
+          className="flex items-center gap-2 rounded-[8px] px-3 py-2 font-sans text-[12.5px]"
+          style={{
+            background: passed ? "var(--ok-soft)" : "var(--err-soft)",
+            border: `1px solid ${passed ? "oklch(0.82 0.16 145 / 0.4)" : "oklch(0.72 0.19 25 / 0.4)"}`,
+            color: passed ? "var(--ok)" : "var(--err)",
+          }}
+        >
+          {passed ? (
+            <Check className="size-4" aria-hidden="true" />
+          ) : (
+            <X className="size-4" aria-hidden="true" />
+          )}
+          <b>{passed ? "Accepted — 期待出力と一致!" : "Wrong Answer — 期待出力と一致しません"}</b>
+        </div>
+      ) : null}
+
+      {hasStdout ? (
+        <div
+          className="overflow-hidden rounded-[8px]"
+          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+        >
+          <div
+            className="border-b px-3 py-1.5 font-mono text-[11px]"
+            style={{
+              borderColor: "var(--line-1)",
+              background: "var(--bg-2)",
+              color: "var(--text-3)",
+            }}
+          >
+            stdout
+          </div>
+          <pre className="m-0 whitespace-pre-wrap break-all p-3" style={{ color: "var(--text-1)" }}>
+            {output.stdout}
+          </pre>
+        </div>
+      ) : null}
+
+      {hasStderr ? (
+        <div
+          className="overflow-hidden rounded-[8px]"
+          style={{ background: "var(--bg-1)", border: "1px solid oklch(0.72 0.19 25 / 0.4)" }}
+        >
+          <div
+            className="border-b px-3 py-1.5 font-mono text-[11px]"
+            style={{
+              borderColor: "var(--line-1)",
+              background: "var(--bg-2)",
+              color: "var(--err)",
+            }}
+          >
+            stderr
+          </div>
+          <pre className="m-0 whitespace-pre-wrap break-all p-3" style={{ color: "var(--err)" }}>
+            {output.stderr}
+          </pre>
+        </div>
+      ) : null}
+
+      {output.timedOut ? (
+        <div
+          className="rounded-[8px] px-3 py-2 font-sans text-[12.5px]"
+          style={{
+            background: "var(--warn-soft)",
+            border: "1px solid oklch(0.84 0.15 85 / 0.4)",
+            color: "var(--warn)",
+          }}
+        >
+          ⏱ タイムアウト (5s)
+        </div>
+      ) : null}
+
+      {!hasStdout && !hasStderr && !output.timedOut ? (
+        <div className="font-sans" style={{ color: "var(--text-3)" }}>
+          (出力なし)
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
+++ b/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
@@ -129,7 +129,6 @@ export default function LessonClient({
               style={{
                 color: "var(--text-1)",
                 background: "var(--bg-2)",
-                boxShadow: "inset 0 -2px 0 var(--accent-solid)",
               }}
             >
               <FileText className="size-3.5" aria-hidden="true" /> 問題
@@ -339,7 +338,6 @@ export default function LessonClient({
                 style={{
                   color: "var(--text-1)",
                   background: "var(--bg-2)",
-                  boxShadow: "inset 0 -2px 0 var(--accent-solid)",
                 }}
               >
                 <Play className="size-3" aria-hidden="true" /> 実行結果

--- a/src/app/(protected)/courses/[slug]/page.tsx
+++ b/src/app/(protected)/courses/[slug]/page.tsx
@@ -1,13 +1,19 @@
-import { Check } from "lucide-react";
+import { ArrowLeft, BookText, Play, Star } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Card, CardContent } from "@/components/ui/card";
 import { requireAuth } from "@/lib/auth";
 import { NotFoundError } from "@/lib/errors";
+import { cn } from "@/lib/utils";
 import { getCourseBySlug } from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
 
 export const dynamic = "force-dynamic";
+
+function statusClass(state: "ac" | "try" | "none") {
+  if (state === "ac") return "cm-status-ac";
+  if (state === "try") return "cm-status-try";
+  return "cm-status-none";
+}
 
 export default async function CoursePage({ params }: PageProps<"/courses/[slug]">) {
   const session = await requireAuth();
@@ -26,43 +32,193 @@ export default async function CoursePage({ params }: PageProps<"/courses/[slug]"
     course.lessons.map((l) => l.id),
   );
   const completedIds = new Set(completed);
+  const done = course.lessons.filter((l) => completedIds.has(l.id)).length;
+  const total = course.lessons.length;
+  const pct = total === 0 ? 0 : Math.round((done / total) * 100);
+  const firstLesson = course.lessons[0];
 
   return (
-    <div className="mx-auto max-w-3xl flex-1 px-6 py-16">
-      <Link href="/" className="text-sm text-zinc-500 hover:underline">
-        ← コース一覧
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
+      <Link
+        href="/"
+        className="mb-4 inline-flex items-center gap-1 text-[13px]"
+        style={{ color: "var(--text-3)" }}
+      >
+        <ArrowLeft className="size-3.5" aria-hidden="true" /> コース一覧
       </Link>
-      <h1 className="mt-3 text-3xl font-bold">{course.title}</h1>
-      <p className="mt-2 text-zinc-600 dark:text-zinc-400">{course.description}</p>
 
-      <ol className="mt-10 space-y-2">
-        {course.lessons.map((l, i) => {
-          const done = completedIds.has(l.id);
-          return (
-            <li key={l.id}>
+      {/* Hero */}
+      <section
+        className="relative mb-7 overflow-hidden rounded-[20px] p-8"
+        style={{ border: "1px solid var(--line-1)", isolation: "isolate", minHeight: 220 }}
+      >
+        <div aria-hidden="true" className="cm-cover-1 absolute inset-0" style={{ zIndex: 0 }} />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0"
+          style={{
+            background:
+              "linear-gradient(180deg, transparent 20%, var(--bg-0) 100%), linear-gradient(90deg, var(--bg-0) 0%, transparent 60%)",
+            zIndex: 0,
+          }}
+        />
+
+        <div className="relative z-10 max-w-[680px]">
+          <div className="flex items-center gap-2">
+            <span className="cm-diff-badge cm-diff-1">初級</span>
+            <span className="cm-chip">{total} レッスン</span>
+          </div>
+          <h1 className="my-3 font-bold text-[32px] tracking-tight">{course.title}</h1>
+          <p className="m-0 text-[14px]" style={{ color: "var(--text-2)" }}>
+            {course.description}
+          </p>
+
+          <div className="mt-5 flex flex-wrap items-center gap-2.5">
+            {firstLesson ? (
               <Link
-                className="block transition hover:opacity-80"
-                href={`/courses/${course.slug}/lessons/${l.slug}`}
+                href={`/courses/${course.slug}/lessons/${firstLesson.slug}`}
+                className="inline-flex items-center gap-2 rounded-[10px] px-4 py-2 font-semibold text-[13px] transition"
+                style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
               >
-                <Card size="sm">
-                  <CardContent className="flex items-center gap-4">
-                    <span className="w-8 shrink-0 font-mono text-sm text-muted-foreground">
-                      #{i + 1}
-                    </span>
-                    <span className="flex-1 font-medium">{l.title}</span>
-                    {done && (
-                      <Check
-                        aria-label="クリア済み"
-                        className="size-4 shrink-0 text-emerald-600 dark:text-emerald-400"
-                      />
-                    )}
-                  </CardContent>
-                </Card>
+                <Play className="size-3.5" aria-hidden="true" />
+                {done > 0 && done < total ? "続きから学ぶ" : "最初から始める"}
               </Link>
-            </li>
+            ) : null}
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-[10px] px-4 py-2 text-[13px]"
+              style={{
+                background: "var(--bg-2)",
+                border: "1px solid var(--line-2)",
+                color: "var(--text-1)",
+              }}
+            >
+              <Star className="size-3.5" aria-hidden="true" /> お気に入り
+            </button>
+          </div>
+        </div>
+
+        <div
+          className="relative z-10 mt-5 grid items-center gap-4 border-t pt-4"
+          style={{ borderColor: "var(--line-1)", gridTemplateColumns: "1fr auto" }}
+        >
+          <div>
+            <div className="mb-1.5 flex justify-between">
+              <span className="cm-label">あなたの進捗</span>
+              <span className="cm-mono" style={{ color: "var(--text-3)" }}>
+                {done}/{total} 完了
+              </span>
+            </div>
+            <div className="cm-progress">
+              <span style={{ width: `${pct}%` }} />
+            </div>
+          </div>
+          <div className="flex gap-7">
+            <Stat value={`${pct}`} unit="%" label="完走率" />
+            <Stat value={`${total}`} label="レッスン" />
+          </div>
+        </div>
+      </section>
+
+      {/* Lesson list */}
+      <div className="mb-4 flex items-baseline justify-between">
+        <div>
+          <h2 className="m-0 font-semibold text-[18px] tracking-tight">Lessons</h2>
+          <span className="text-xs" style={{ color: "var(--text-3)" }}>
+            順番に取り組むのがおすすめ
+          </span>
+        </div>
+      </div>
+
+      <div
+        className="overflow-hidden rounded-[14px]"
+        style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+      >
+        <div
+          className="grid items-center gap-4 border-b px-5 py-2.5"
+          style={{
+            gridTemplateColumns: "40px 24px 1fr 120px",
+            background: "var(--bg-2)",
+            borderColor: "var(--line-1)",
+            color: "var(--text-4)",
+            fontSize: 11,
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+          }}
+        >
+          <span>#</span>
+          <span />
+          <span>Title</span>
+          <span>Difficulty</span>
+        </div>
+
+        {course.lessons.map((l, i) => {
+          const state: "ac" | "none" = completedIds.has(l.id) ? "ac" : "none";
+          return (
+            <Link
+              key={l.id}
+              href={`/courses/${course.slug}/lessons/${l.slug}`}
+              className="grid cursor-pointer items-center gap-4 border-b px-5 py-3.5 transition last:border-b-0 hover:bg-[var(--bg-2)]"
+              style={{
+                gridTemplateColumns: "40px 24px 1fr 120px",
+                borderColor: "var(--line-1)",
+              }}
+            >
+              <span className="cm-mono" style={{ color: "var(--text-4)" }}>
+                {String(i + 1).padStart(2, "0")}
+              </span>
+              <span
+                role="img"
+                aria-label={state === "ac" ? "クリア済み" : "未着手"}
+                title={state === "ac" ? "クリア済み" : "未着手"}
+                className={cn("cm-status-dot", statusClass(state))}
+              />
+              <div>
+                <div className="font-medium text-[14px]" style={{ color: "var(--text-1)" }}>
+                  {l.title}
+                </div>
+                <div
+                  className="mt-0.5 inline-flex items-center gap-1 text-[12px]"
+                  style={{ color: "var(--text-3)" }}
+                >
+                  <BookText className="size-3" aria-hidden="true" />
+                  レッスン {i + 1}
+                </div>
+              </div>
+              <span>
+                <span className="cm-diff-badge cm-diff-1">初級</span>
+              </span>
+            </Link>
           );
         })}
-      </ol>
+
+        {course.lessons.length === 0 ? (
+          <div className="px-5 py-10 text-center text-[13px]" style={{ color: "var(--text-3)" }}>
+            このコースにはまだレッスンがありません。
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ value, unit, label }: { value: string; unit?: string; label: string }) {
+  return (
+    <div>
+      <div
+        className="font-semibold text-[22px] tracking-tight"
+        style={{ fontFamily: "var(--font-mono-family)" }}
+      >
+        {value}
+        {unit ? (
+          <span className="text-[14px]" style={{ color: "var(--text-3)" }}>
+            {unit}
+          </span>
+        ) : null}
+      </div>
+      <div className="text-[11px] uppercase tracking-[0.08em]" style={{ color: "var(--text-4)" }}>
+        {label}
+      </div>
     </div>
   );
 }

--- a/src/app/(protected)/courses/[slug]/page.tsx
+++ b/src/app/(protected)/courses/[slug]/page.tsx
@@ -86,7 +86,9 @@ export default async function CoursePage({ params }: PageProps<"/courses/[slug]"
             ) : null}
             <button
               type="button"
-              className="inline-flex items-center gap-2 rounded-[10px] px-4 py-2 text-[13px]"
+              disabled
+              aria-label="お気に入り (近日公開)"
+              className="inline-flex cursor-not-allowed items-center gap-2 rounded-[10px] px-4 py-2 text-[13px] opacity-60"
               style={{
                 background: "var(--bg-2)",
                 border: "1px solid var(--line-2)",
@@ -152,51 +154,58 @@ export default async function CoursePage({ params }: PageProps<"/courses/[slug]"
           <span>Difficulty</span>
         </div>
 
-        {course.lessons.map((l, i) => {
-          const state: "ac" | "none" = completedIds.has(l.id) ? "ac" : "none";
-          return (
-            <Link
-              key={l.id}
-              href={`/courses/${course.slug}/lessons/${l.slug}`}
-              className="grid cursor-pointer items-center gap-4 border-b px-5 py-3.5 transition last:border-b-0 hover:bg-[var(--bg-2)]"
-              style={{
-                gridTemplateColumns: "40px 24px 1fr 120px",
-                borderColor: "var(--line-1)",
-              }}
-            >
-              <span className="cm-mono" style={{ color: "var(--text-4)" }}>
-                {String(i + 1).padStart(2, "0")}
-              </span>
-              <span
-                role="img"
-                aria-label={state === "ac" ? "クリア済み" : "未着手"}
-                title={state === "ac" ? "クリア済み" : "未着手"}
-                className={cn("cm-status-dot", statusClass(state))}
-              />
-              <div>
-                <div className="font-medium text-[14px]" style={{ color: "var(--text-1)" }}>
-                  {l.title}
-                </div>
-                <div
-                  className="mt-0.5 inline-flex items-center gap-1 text-[12px]"
-                  style={{ color: "var(--text-3)" }}
-                >
-                  <BookText className="size-3" aria-hidden="true" />
-                  レッスン {i + 1}
-                </div>
-              </div>
-              <span>
-                <span className="cm-diff-badge cm-diff-1">初級</span>
-              </span>
-            </Link>
-          );
-        })}
-
         {course.lessons.length === 0 ? (
           <div className="px-5 py-10 text-center text-[13px]" style={{ color: "var(--text-3)" }}>
             このコースにはまだレッスンがありません。
           </div>
-        ) : null}
+        ) : (
+          <ul>
+            {course.lessons.map((l, i) => {
+              const state: "ac" | "none" = completedIds.has(l.id) ? "ac" : "none";
+              const isLast = i === course.lessons.length - 1;
+              return (
+                <li key={l.id}>
+                  <Link
+                    href={`/courses/${course.slug}/lessons/${l.slug}`}
+                    className={cn(
+                      "grid cursor-pointer items-center gap-4 px-5 py-3.5 transition hover:bg-[var(--bg-2)]",
+                      !isLast && "border-b",
+                    )}
+                    style={{
+                      gridTemplateColumns: "40px 24px 1fr 120px",
+                      borderColor: "var(--line-1)",
+                    }}
+                  >
+                    <span className="cm-mono" style={{ color: "var(--text-4)" }}>
+                      {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <span
+                      role="img"
+                      aria-label={state === "ac" ? "クリア済み" : "未着手"}
+                      title={state === "ac" ? "クリア済み" : "未着手"}
+                      className={cn("cm-status-dot", statusClass(state))}
+                    />
+                    <div>
+                      <div className="font-medium text-[14px]" style={{ color: "var(--text-1)" }}>
+                        {l.title}
+                      </div>
+                      <div
+                        className="mt-0.5 inline-flex items-center gap-1 text-[12px]"
+                        style={{ color: "var(--text-3)" }}
+                      >
+                        <BookText className="size-3" aria-hidden="true" />
+                        レッスン {i + 1}
+                      </div>
+                    </div>
+                    <span>
+                      <span className="cm-diff-badge cm-diff-1">初級</span>
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/app/(protected)/dashboard/_components/CourseListItem.tsx
+++ b/src/app/(protected)/dashboard/_components/CourseListItem.tsx
@@ -1,10 +1,9 @@
 "use client";
 
+import { FileText, Pencil } from "lucide-react";
 import Link from "next/link";
 import { useTransition } from "react";
 import { togglePublishCourseAction } from "@/actions/dashboard/course";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { DeleteCourseButton } from "./DeleteCourseButton";
 import { PublishBadge } from "./PublishBadge";
 
@@ -32,35 +31,74 @@ export function CourseListItem({ course }: Props) {
   };
 
   return (
-    <Card size="sm">
-      <CardContent className="flex items-center gap-4">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <Link
-              href={`/dashboard/courses/${course.id}`}
-              className="truncate font-semibold hover:underline"
-            >
-              {course.title}
-            </Link>
-            <PublishBadge isPublished={course.isPublished} />
-          </div>
-          <p className="mt-1 truncate text-xs text-muted-foreground">
-            /{course.slug} · レッスン {course.lessonCount} 件
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <Button
-            onClick={onToggle}
-            disabled={isPending}
-            size="sm"
-            type="button"
-            variant={course.isPublished ? "outline" : "default"}
-          >
-            {course.isPublished ? "非公開にする" : "公開する"}
-          </Button>
+    <article
+      className="flex h-full flex-col gap-3 rounded-[14px] p-4 transition hover:-translate-y-0.5 hover:border-[color:var(--line-3)]"
+      style={{
+        background: "var(--bg-1)",
+        border: "1px solid var(--line-1)",
+        minHeight: 180,
+      }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <Link
+          href={`/dashboard/courses/${course.id}`}
+          className="min-w-0 flex-1 font-semibold text-[15px] leading-snug tracking-tight hover:underline"
+          style={{ color: "var(--text-1)" }}
+        >
+          {course.title}
+        </Link>
+        <PublishBadge isPublished={course.isPublished} />
+      </div>
+
+      {course.description ? (
+        <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
+          {course.description}
+        </p>
+      ) : null}
+
+      <div className="flex items-center gap-3 text-[12px]" style={{ color: "var(--text-3)" }}>
+        <span className="inline-flex items-center gap-1.5">
+          <FileText className="size-3" aria-hidden="true" />
+          <b style={{ color: "var(--text-1)" }}>{course.lessonCount}</b> レッスン
+        </span>
+        <span className="font-mono text-[11px]" style={{ color: "var(--text-4)" }}>
+          /{course.slug}
+        </span>
+      </div>
+
+      <div
+        className="mt-auto flex items-center gap-2 border-t pt-3"
+        style={{ borderColor: "var(--line-1)" }}
+      >
+        <Link
+          href={`/dashboard/courses/${course.id}`}
+          className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-[12px] transition"
+          style={{
+            background: "var(--bg-2)",
+            border: "1px solid var(--line-2)",
+            color: "var(--text-1)",
+          }}
+        >
+          <Pencil className="size-3" aria-hidden="true" /> 編集
+        </Link>
+        <button
+          type="button"
+          onClick={onToggle}
+          disabled={isPending}
+          className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-[12px] transition disabled:opacity-50"
+          style={{
+            background: course.isPublished ? "var(--bg-2)" : "var(--accent-solid)",
+            border: `1px solid ${course.isPublished ? "var(--line-2)" : "transparent"}`,
+            color: course.isPublished ? "var(--text-1)" : "var(--accent-ink)",
+            fontWeight: course.isPublished ? 500 : 600,
+          }}
+        >
+          {course.isPublished ? "非公開にする" : "公開する"}
+        </button>
+        <div className="ml-auto">
           <DeleteCourseButton courseId={course.id} title={course.title} />
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </article>
   );
 }

--- a/src/app/(protected)/dashboard/_components/PublishBadge.tsx
+++ b/src/app/(protected)/dashboard/_components/PublishBadge.tsx
@@ -1,19 +1,11 @@
-import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 
 export function PublishBadge({ isPublished }: { isPublished: boolean }) {
-  if (isPublished) {
-    return (
-      <Badge
-        className="bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
-        variant="secondary"
-      >
-        公開
-      </Badge>
-    );
-  }
   return (
-    <Badge className="text-zinc-500" variant="outline">
-      非公開
-    </Badge>
+    <span
+      className={cn("cm-status-pill", isPublished ? "cm-status-pill-pub" : "cm-status-pill-draft")}
+    >
+      {isPublished ? "公開中" : "下書き"}
+    </span>
   );
 }

--- a/src/app/(protected)/dashboard/layout.tsx
+++ b/src/app/(protected)/dashboard/layout.tsx
@@ -1,31 +1,6 @@
-import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   await requireAuth();
-
-  return (
-    <div className="flex min-h-[calc(100vh-2.5rem)] flex-1">
-      <aside className="hidden w-56 shrink-0 border-r border-zinc-200 p-4 text-sm dark:border-zinc-800 md:block">
-        <nav aria-label="ダッシュボード">
-          <h2 className="mb-3 font-semibold text-zinc-500 uppercase tracking-wide text-xs">
-            クリエイター
-          </h2>
-          <ul className="space-y-1">
-            <li>
-              <Link href="/dashboard" className="block rounded-md px-2 py-1 hover:bg-muted">
-                マイコース
-              </Link>
-            </li>
-            <li>
-              <Link href="/" className="block rounded-md px-2 py-1 hover:bg-muted">
-                学習画面へ戻る
-              </Link>
-            </li>
-          </ul>
-        </nav>
-      </aside>
-      <main className="flex-1">{children}</main>
-    </div>
-  );
+  return <main className="flex-1">{children}</main>;
 }

--- a/src/app/(protected)/dashboard/layout.tsx
+++ b/src/app/(protected)/dashboard/layout.tsx
@@ -1,6 +1,3 @@
-import { requireAuth } from "@/lib/auth";
-
-export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
-  await requireAuth();
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return <main className="flex-1">{children}</main>;
 }

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,6 +1,5 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { buttonVariants } from "@/components/ui/button";
 import { requireAuth } from "@/lib/auth";
 import { getMyCourses } from "@/services/courseService";
 import { CourseListItem } from "./_components/CourseListItem";
@@ -11,37 +10,57 @@ export default async function DashboardPage() {
   const session = await requireAuth();
   const courses = await getMyCourses(session.userId);
 
+  const publishedCount = courses.filter((c) => c.isPublished).length;
+  const draftCount = courses.length - publishedCount;
+  const totalLessons = courses.reduce((acc, c) => acc + c.lessons.length, 0);
+
   return (
-    <div className="mx-auto max-w-3xl px-6 py-10">
-      <header className="mb-8 flex items-start justify-between gap-4">
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
+      <header className="mb-5 flex flex-wrap items-end justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold">マイコース</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            自分が作成したコースを管理できます。公開するとすべての学習者が閲覧可能になります。
+          <h1 className="m-0 font-semibold text-[24px] tracking-tight">あなたのコース</h1>
+          <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
+            コースを作って、学びたい人のためのレッスンを公開しよう。
           </p>
         </div>
         <Link
           href="/dashboard/courses/new"
-          className={buttonVariants({ variant: "default", size: "sm" })}
+          className="inline-flex items-center gap-2 rounded-[10px] px-4 py-2 font-semibold text-[13px] transition"
+          style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
         >
-          <Plus aria-hidden="true" />
-          コース作成
+          <Plus className="size-3.5" aria-hidden="true" /> 新しいコース
         </Link>
       </header>
 
+      <div className="mb-7 grid gap-4" style={{ gridTemplateColumns: "repeat(3, minmax(0, 1fr))" }}>
+        <StatBox k="公開中" v={String(publishedCount)} />
+        <StatBox k="下書き" v={String(draftCount)} />
+        <StatBox k="総レッスン数" v={String(totalLessons)} />
+      </div>
+
       {courses.length === 0 ? (
-        <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-muted-foreground dark:border-zinc-700">
-          まだコースがありません。
-          <br />
+        <div
+          className="rounded-[14px] px-8 py-14 text-center text-[13px]"
+          style={{
+            background: "var(--bg-1)",
+            border: "1px dashed var(--line-3)",
+            color: "var(--text-3)",
+          }}
+        >
+          <div className="mb-2">まだコースがありません。</div>
           <Link
-            className="mt-3 inline-block text-primary hover:underline"
             href="/dashboard/courses/new"
+            className="inline-flex items-center gap-1.5 text-[13px]"
+            style={{ color: "var(--accent-solid)" }}
           >
-            最初のコースを作成する
+            <Plus className="size-3.5" aria-hidden="true" /> 最初のコースを作成する
           </Link>
         </div>
       ) : (
-        <ul className="space-y-3">
+        <ul
+          className="grid gap-4"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
+        >
           {courses.map((c) => (
             <li key={c.id}>
               <CourseListItem
@@ -56,8 +75,42 @@ export default async function DashboardPage() {
               />
             </li>
           ))}
+          <li>
+            <Link
+              href="/dashboard/courses/new"
+              className="flex h-full min-h-[180px] flex-col items-center justify-center gap-2 rounded-[14px] p-4 text-center text-[13px] transition hover:border-[color:var(--accent-line)] hover:text-[var(--accent-solid)]"
+              style={{
+                border: "1px dashed var(--line-3)",
+                background: "transparent",
+                color: "var(--text-3)",
+              }}
+            >
+              <Plus className="size-7" aria-hidden="true" />
+              <div>新しいコース</div>
+              <div className="text-[11px]" style={{ color: "var(--text-4)" }}>
+                ゼロから作る
+              </div>
+            </Link>
+          </li>
         </ul>
       )}
+    </div>
+  );
+}
+
+function StatBox({ k, v }: { k: string; v: string }) {
+  return (
+    <div
+      className="rounded-[14px] p-4"
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <div className="cm-label mb-1.5">{k}</div>
+      <div
+        className="font-semibold text-[28px] tracking-tight"
+        style={{ fontFamily: "var(--font-mono-family)" }}
+      >
+        {v}
+      </div>
     </div>
   );
 }

--- a/src/app/(protected)/explore/page.tsx
+++ b/src/app/(protected)/explore/page.tsx
@@ -1,7 +1,8 @@
-import { BookText, Compass } from "lucide-react";
+import { BookText, LayoutGrid, Rows3 } from "lucide-react";
 import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 import { cn } from "@/lib/utils";
+import type { CourseAuthor } from "@/repositories";
 import { getPublishedCoursesByNewest } from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
 
@@ -16,6 +17,27 @@ const COVER_VARIANTS = [
   "cm-cover-6",
 ] as const;
 
+const DIFFICULTY_FILTERS = [
+  { key: "beginner", label: "初級" },
+  { key: "intermediate", label: "中級" },
+  { key: "advanced", label: "上級" },
+] as const;
+
+const TAG_FILTERS = ["TypeScript", "基礎", "型", "関数", "配列", "オブジェクト", "入門"] as const;
+
+const LANGUAGE_FILTERS = [
+  { key: "typescript", label: "TypeScript", active: true },
+  { key: "javascript", label: "JavaScript", active: false },
+  { key: "python", label: "Python", active: false },
+] as const;
+
+const SORT_OPTIONS = [
+  { key: "newest", label: "新着" },
+  { key: "popular", label: "人気" },
+  { key: "ac-rate", label: "AC率高" },
+  { key: "unchallenged", label: "未挑戦" },
+] as const;
+
 function coverFor(index: number) {
   return COVER_VARIANTS[index % COVER_VARIANTS.length];
 }
@@ -26,32 +48,169 @@ function glyphFor(title: string) {
   return Array.from(trimmed).slice(0, 2).join("").toUpperCase();
 }
 
+function authorLabel(author: CourseAuthor | null): string {
+  if (!author) return "Anonymous";
+  return author.name ?? (author.email ? author.email.split("@")[0] : "Anonymous");
+}
+
+function authorInitial(author: CourseAuthor | null): string {
+  const label = authorLabel(author);
+  return (Array.from(label.trim())[0] ?? "?").toUpperCase();
+}
+
 export default async function ExplorePage() {
   const session = await requireAuth();
   const [courses, completed] = await Promise.all([
     getPublishedCoursesByNewest(),
     getCompletedLessonIdsByUser(session.userId),
   ]);
-
   const completedIds = new Set(completed);
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
-      <header className="mb-7 flex flex-wrap items-end justify-between gap-4">
-        <div>
-          <div className="cm-label mb-1 inline-flex items-center gap-1.5">
-            <Compass className="size-3" aria-hidden="true" /> 探す
-          </div>
-          <h1 className="m-0 font-semibold text-[24px] tracking-tight">新着コース</h1>
-          <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
-            公開されたばかりのコースから順に表示しています。
-          </p>
-        </div>
-        <div className="cm-mono text-[12px]" style={{ color: "var(--text-3)" }}>
-          全 <b style={{ color: "var(--text-1)" }}>{courses.length}</b> 件
-        </div>
+      <header className="mb-7">
+        <h1 className="m-0 font-bold text-[26px] tracking-tight">Explore — コミュニティの問題集</h1>
+        <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
+          他のユーザーが作った Collection を探そう
+        </p>
       </header>
 
+      <div className="grid grid-cols-1 gap-7 md:grid-cols-[240px_minmax(0,1fr)]">
+        <FilterPanel />
+        <ExploreMain courses={courses} completedIds={completedIds} />
+      </div>
+    </div>
+  );
+}
+
+function FilterPanel() {
+  return (
+    <aside
+      className="h-max rounded-[14px] p-4 md:sticky md:top-20"
+      style={{
+        background: "var(--bg-1)",
+        border: "1px solid var(--line-1)",
+      }}
+      aria-label="フィルタ (UI プレビュー)"
+    >
+      <FilterGroup title="難易度">
+        <ul className="space-y-0.5">
+          {DIFFICULTY_FILTERS.map((d) => (
+            <li key={d.key}>
+              <CheckRow label={d.label} count={0} />
+            </li>
+          ))}
+        </ul>
+      </FilterGroup>
+
+      <FilterGroup title="タグ">
+        <div className="flex flex-wrap gap-1.5">
+          {TAG_FILTERS.map((tag) => (
+            <TagChip key={tag} label={tag} />
+          ))}
+        </div>
+      </FilterGroup>
+
+      <FilterGroup title="対応言語">
+        <ul className="space-y-0.5">
+          {LANGUAGE_FILTERS.map((l) => (
+            <li key={l.key}>
+              <CheckRow label={l.label} checked={l.active} />
+            </li>
+          ))}
+        </ul>
+      </FilterGroup>
+
+      <button
+        type="button"
+        disabled
+        aria-disabled="true"
+        className="mt-2 inline-flex w-full cursor-not-allowed items-center justify-center rounded-[6px] px-2.5 py-1.5 text-[12px] opacity-60"
+        style={{ color: "var(--text-2)" }}
+      >
+        フィルタをクリア
+      </button>
+    </aside>
+  );
+}
+
+function FilterGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-5 last:mb-0">
+      <h2
+        className="m-0 mb-2 text-[11px] uppercase tracking-[0.08em]"
+        style={{ color: "var(--text-4)", fontWeight: 600 }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function CheckRow({
+  label,
+  count,
+  checked = false,
+}: {
+  label: string;
+  count?: number;
+  checked?: boolean;
+}) {
+  return (
+    <label
+      className="flex cursor-not-allowed items-center justify-between py-1 text-[13px] opacity-70"
+      style={{ color: "var(--text-2)" }}
+    >
+      <span className="inline-flex items-center gap-2">
+        <input
+          type="checkbox"
+          disabled
+          defaultChecked={checked}
+          aria-disabled="true"
+          className="cursor-not-allowed"
+          style={{ accentColor: "var(--accent-solid)" }}
+        />
+        {label}
+      </span>
+      {typeof count === "number" ? (
+        <span className="cm-mono" style={{ color: "var(--text-4)" }}>
+          {count}
+        </span>
+      ) : null}
+    </label>
+  );
+}
+
+function TagChip({ label }: { label: string }) {
+  return (
+    <span
+      className="cursor-not-allowed rounded-[999px] border px-2.5 py-0.5 text-[12px] opacity-70"
+      style={{
+        background: "var(--bg-2)",
+        borderColor: "var(--line-1)",
+        color: "var(--text-2)",
+      }}
+      aria-disabled="true"
+      role="presentation"
+    >
+      {label}
+    </span>
+  );
+}
+
+type ExploreCourse = Awaited<ReturnType<typeof getPublishedCoursesByNewest>>[number];
+
+function ExploreMain({
+  courses,
+  completedIds,
+}: {
+  courses: ExploreCourse[];
+  completedIds: Set<string>;
+}) {
+  return (
+    <main className="min-w-0">
+      <Toolbar total={courses.length} />
       {courses.length === 0 ? (
         <div
           className="rounded-[14px] px-8 py-14 text-center text-[13px]"
@@ -66,72 +225,135 @@ export default async function ExplorePage() {
       ) : (
         <ul
           className="grid gap-4"
-          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
         >
-          {courses.map((c, idx) => {
-            const total = c.lessons.length;
-            const done = c.lessons.filter((l) => completedIds.has(l.id)).length;
-            const pct = total === 0 ? 0 : Math.round((done / total) * 100);
-            return (
-              <li key={c.id}>
-                <Link
-                  href={`/courses/${c.slug}`}
-                  className={cn(
-                    "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
-                    "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
-                  )}
-                  style={{
-                    background: "var(--bg-1)",
-                    border: "1px solid var(--line-1)",
-                  }}
-                >
-                  <div className={cn("cm-cover", coverFor(idx))}>
-                    <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
-                      <span className="cm-diff-badge cm-diff-1">初級</span>
-                    </div>
-                    <span className="cm-cover-glyph" aria-hidden="true">
-                      {glyphFor(c.title)}
-                    </span>
-                  </div>
-                  <div className="flex flex-1 flex-col gap-2.5 p-4">
-                    <h3
-                      className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
-                      style={{ color: "var(--text-1)" }}
-                    >
-                      {c.title}
-                    </h3>
-                    {c.description ? (
-                      <p
-                        className="m-0 line-clamp-2 text-[12.5px]"
-                        style={{ color: "var(--text-3)" }}
-                      >
-                        {c.description}
-                      </p>
-                    ) : null}
-                    <div className="mt-auto flex items-center gap-3">
-                      <div className="cm-progress flex-1">
-                        <span style={{ width: `${pct}%` }} />
-                      </div>
-                      <span className="cm-mono" style={{ color: "var(--text-3)" }}>
-                        {done}/{total}
-                      </span>
-                    </div>
-                    <div
-                      className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
-                      style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
-                    >
-                      <span className="inline-flex items-center gap-1">
-                        <BookText className="size-3" aria-hidden="true" />
-                        <b style={{ color: "var(--text-1)" }}>{total}</b> レッスン
-                      </span>
-                    </div>
-                  </div>
-                </Link>
-              </li>
-            );
-          })}
+          {courses.map((c, idx) => (
+            <li key={c.id}>
+              <ExploreCard course={c} index={idx} completedIds={completedIds} />
+            </li>
+          ))}
         </ul>
       )}
+    </main>
+  );
+}
+
+function Toolbar({ total }: { total: number }) {
+  return (
+    <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+      <div className="text-[13px]" style={{ color: "var(--text-3)" }}>
+        <b style={{ color: "var(--text-1)" }}>{total}</b> / {total} 件
+      </div>
+      <div className="flex items-center gap-2">
+        <fieldset className="cm-segment m-0 border-0 p-[3px]" disabled>
+          <legend className="sr-only">並び替え (UI プレビュー)</legend>
+          {SORT_OPTIONS.map((opt) => (
+            <button
+              key={opt.key}
+              type="button"
+              aria-pressed={opt.key === "newest"}
+              className="cursor-not-allowed"
+            >
+              {opt.label}
+            </button>
+          ))}
+        </fieldset>
+        <fieldset className="cm-segment m-0 border-0 p-[3px]">
+          <legend className="sr-only">表示切替 (UI プレビュー)</legend>
+          <button type="button" aria-pressed="true" aria-label="グリッド表示">
+            <LayoutGrid className="size-3.5" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            disabled
+            aria-pressed="false"
+            aria-label="リスト表示 (準備中)"
+            className="cursor-not-allowed"
+          >
+            <Rows3 className="size-3.5" aria-hidden="true" />
+          </button>
+        </fieldset>
+      </div>
     </div>
+  );
+}
+
+function ExploreCard({
+  course,
+  index,
+  completedIds,
+}: {
+  course: ExploreCourse;
+  index: number;
+  completedIds: Set<string>;
+}) {
+  const total = course.lessons.length;
+  const done = course.lessons.filter((l) => completedIds.has(l.id)).length;
+  const pct = total === 0 ? 0 : Math.round((done / total) * 100);
+
+  return (
+    <Link
+      href={`/courses/${course.slug}`}
+      className={cn(
+        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
+        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
+      )}
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <div className={cn("cm-cover", coverFor(index))}>
+        <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
+          <span className="cm-diff-badge cm-diff-1">初級</span>
+        </div>
+        <span className="cm-cover-glyph" aria-hidden="true">
+          {glyphFor(course.title)}
+        </span>
+      </div>
+      <div className="flex flex-1 flex-col gap-2.5 p-4">
+        <h3
+          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
+          style={{ color: "var(--text-1)" }}
+        >
+          {course.title}
+        </h3>
+
+        <div className="flex items-center gap-1.5">
+          <span className="cm-avatar cm-avatar-sm" aria-hidden="true">
+            {authorInitial(course.author)}
+          </span>
+          <span className="text-[12px]" style={{ color: "var(--text-3)" }}>
+            {authorLabel(course.author)}
+          </span>
+        </div>
+
+        {course.description ? (
+          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
+            {course.description}
+          </p>
+        ) : null}
+
+        <div className="flex flex-wrap gap-1.5">
+          <span className="cm-chip">#TypeScript</span>
+          <span className="cm-chip">#基礎</span>
+        </div>
+
+        <div className="mt-auto flex items-center gap-3">
+          <div className="cm-progress flex-1">
+            <span style={{ width: `${pct}%` }} />
+          </div>
+          <span className="cm-mono" style={{ color: "var(--text-3)" }}>
+            {done}/{total}
+          </span>
+        </div>
+        <div
+          className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
+          style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
+        >
+          <span className="inline-flex items-center gap-1">
+            <BookText className="size-3" aria-hidden="true" />
+            <b style={{ color: "var(--text-1)" }}>{total}</b> レッスン
+          </span>
+        </div>
+      </div>
+    </Link>
   );
 }

--- a/src/app/(protected)/explore/page.tsx
+++ b/src/app/(protected)/explore/page.tsx
@@ -49,8 +49,9 @@ function glyphFor(title: string) {
 }
 
 function authorLabel(author: CourseAuthor | null): string {
-  if (!author) return "Anonymous";
-  return author.name ?? (author.email ? author.email.split("@")[0] : "Anonymous");
+  // Fall back to "Anonymous" when the author didn't set a display name —
+  // do NOT derive a handle from the email address (privacy).
+  return author?.name ?? "Anonymous";
 }
 
 function authorInitial(author: CourseAuthor | null): string {

--- a/src/app/(protected)/explore/page.tsx
+++ b/src/app/(protected)/explore/page.tsx
@@ -1,0 +1,137 @@
+import { BookText, Compass } from "lucide-react";
+import Link from "next/link";
+import { requireAuth } from "@/lib/auth";
+import { cn } from "@/lib/utils";
+import { getPublishedCoursesByNewest } from "@/services/courseService";
+import { getCompletedLessonIdsByUser } from "@/services/progressService";
+
+export const dynamic = "force-dynamic";
+
+const COVER_VARIANTS = [
+  "cm-cover-1",
+  "cm-cover-2",
+  "cm-cover-3",
+  "cm-cover-4",
+  "cm-cover-5",
+  "cm-cover-6",
+] as const;
+
+function coverFor(index: number) {
+  return COVER_VARIANTS[index % COVER_VARIANTS.length];
+}
+
+function glyphFor(title: string) {
+  const trimmed = title.trim();
+  if (!trimmed) return "TS";
+  return Array.from(trimmed).slice(0, 2).join("").toUpperCase();
+}
+
+export default async function ExplorePage() {
+  const session = await requireAuth();
+  const [courses, completed] = await Promise.all([
+    getPublishedCoursesByNewest(),
+    getCompletedLessonIdsByUser(session.userId),
+  ]);
+
+  const completedIds = new Set(completed);
+
+  return (
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
+      <header className="mb-7 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <div className="cm-label mb-1 inline-flex items-center gap-1.5">
+            <Compass className="size-3" aria-hidden="true" /> 探す
+          </div>
+          <h1 className="m-0 font-semibold text-[24px] tracking-tight">新着コース</h1>
+          <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
+            公開されたばかりのコースから順に表示しています。
+          </p>
+        </div>
+        <div className="cm-mono text-[12px]" style={{ color: "var(--text-3)" }}>
+          全 <b style={{ color: "var(--text-1)" }}>{courses.length}</b> 件
+        </div>
+      </header>
+
+      {courses.length === 0 ? (
+        <div
+          className="rounded-[14px] px-8 py-14 text-center text-[13px]"
+          style={{
+            background: "var(--bg-1)",
+            border: "1px dashed var(--line-3)",
+            color: "var(--text-3)",
+          }}
+        >
+          公開されているコースがまだありません。
+        </div>
+      ) : (
+        <ul
+          className="grid gap-4"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
+        >
+          {courses.map((c, idx) => {
+            const total = c.lessons.length;
+            const done = c.lessons.filter((l) => completedIds.has(l.id)).length;
+            const pct = total === 0 ? 0 : Math.round((done / total) * 100);
+            return (
+              <li key={c.id}>
+                <Link
+                  href={`/courses/${c.slug}`}
+                  className={cn(
+                    "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
+                    "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
+                  )}
+                  style={{
+                    background: "var(--bg-1)",
+                    border: "1px solid var(--line-1)",
+                  }}
+                >
+                  <div className={cn("cm-cover", coverFor(idx))}>
+                    <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
+                      <span className="cm-diff-badge cm-diff-1">初級</span>
+                    </div>
+                    <span className="cm-cover-glyph" aria-hidden="true">
+                      {glyphFor(c.title)}
+                    </span>
+                  </div>
+                  <div className="flex flex-1 flex-col gap-2.5 p-4">
+                    <h3
+                      className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
+                      style={{ color: "var(--text-1)" }}
+                    >
+                      {c.title}
+                    </h3>
+                    {c.description ? (
+                      <p
+                        className="m-0 line-clamp-2 text-[12.5px]"
+                        style={{ color: "var(--text-3)" }}
+                      >
+                        {c.description}
+                      </p>
+                    ) : null}
+                    <div className="mt-auto flex items-center gap-3">
+                      <div className="cm-progress flex-1">
+                        <span style={{ width: `${pct}%` }} />
+                      </div>
+                      <span className="cm-mono" style={{ color: "var(--text-3)" }}>
+                        {done}/{total}
+                      </span>
+                    </div>
+                    <div
+                      className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
+                      style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
+                    >
+                      <span className="inline-flex items-center gap-1">
+                        <BookText className="size-3" aria-hidden="true" />
+                        <b style={{ color: "var(--text-1)" }}>{total}</b> レッスン
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,26 +1,14 @@
-import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
+import { TopBarSwitcher } from "./_components/TopBarSwitcher";
 
 export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {
   const session = await requireAuth();
   const displayName = session.profile.name ?? session.email ?? session.userId;
+  const avatarInitial = (displayName.trim()[0] ?? "?").toUpperCase();
 
   return (
     <>
-      <header className="flex items-center justify-end gap-3 border-b border-zinc-800 px-4 py-2 text-sm">
-        <Link href="/dashboard" className="mr-auto text-zinc-400 hover:text-zinc-200">
-          ダッシュボード
-        </Link>
-        <span className="text-zinc-400">{displayName}</span>
-        <form action="/auth/signout" method="post">
-          <button
-            type="submit"
-            className="rounded-md border border-zinc-700 px-2 py-1 text-xs hover:bg-zinc-900"
-          >
-            Sign out
-          </button>
-        </form>
-      </header>
+      <TopBarSwitcher displayName={displayName} avatarInitial={avatarInitial} />
       {children}
     </>
   );

--- a/src/app/(protected)/me/page.tsx
+++ b/src/app/(protected)/me/page.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Flame, LogOut, Sparkles } from "lucide-react";
+import { CheckCircle2, LogOut, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 import { getCoursesWithLessons, getMyCourses } from "@/services/courseService";
@@ -94,18 +94,54 @@ export default async function MePage() {
           sub={totalLessonsAvailable > 0 ? `${totalLessonsAvailable} 中` : undefined}
         />
         <Stat
-          icon={<Flame className="size-3.5" aria-hidden="true" />}
-          label="連続日数"
-          value="--"
-          sub="集計は近日公開"
-        />
-        <Stat
           icon={<Sparkles className="size-3.5" aria-hidden="true" />}
           label="作成したコース"
           value={String(createdCount)}
           sub={`${publishedCount} 公開中`}
         />
       </div>
+
+      {/* Learning heatmap (placeholder) */}
+      <section className="mb-7">
+        <div className="mb-4">
+          <h2 className="m-0 font-semibold text-[18px] tracking-tight">学習ヒートマップ</h2>
+          <span className="text-xs" style={{ color: "var(--text-3)" }}>
+            過去52週間の活動 (準備中)
+          </span>
+        </div>
+        <div
+          className="overflow-x-auto rounded-[14px]"
+          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+        >
+          <div
+            className="grid gap-[3px] p-4"
+            style={{
+              gridAutoFlow: "column",
+              gridTemplateRows: "repeat(7, 10px)",
+              width: "max-content",
+            }}
+          >
+            {Array.from({ length: 7 * 52 }, (_, i) => `cell-${i}`).map((id) => (
+              <div key={id} className="cm-heat-cell" />
+            ))}
+          </div>
+          <div
+            className="flex items-center justify-between border-t px-4 py-2.5 text-[12px]"
+            style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
+          >
+            <span>活動データは近日公開</span>
+            <div className="flex items-center gap-1 text-[11px]" style={{ color: "var(--text-4)" }}>
+              少ない
+              <span className="cm-heat-cell" />
+              <span className="cm-heat-cell cm-heat-1" />
+              <span className="cm-heat-cell cm-heat-2" />
+              <span className="cm-heat-cell cm-heat-3" />
+              <span className="cm-heat-cell cm-heat-4" />
+              多い
+            </div>
+          </div>
+        </div>
+      </section>
 
       {/* My courses */}
       <section>

--- a/src/app/(protected)/me/page.tsx
+++ b/src/app/(protected)/me/page.tsx
@@ -96,8 +96,8 @@ export default async function MePage() {
         <Stat
           icon={<Flame className="size-3.5" aria-hidden="true" />}
           label="連続日数"
-          value="0"
-          unit="日"
+          value="--"
+          sub="集計は近日公開"
         />
         <Stat
           icon={<Sparkles className="size-3.5" aria-hidden="true" />}

--- a/src/app/(protected)/me/page.tsx
+++ b/src/app/(protected)/me/page.tsx
@@ -1,0 +1,244 @@
+import { CheckCircle2, Flame, LogOut, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { requireAuth } from "@/lib/auth";
+import { getCoursesWithLessons, getMyCourses } from "@/services/courseService";
+import { getCompletedLessonIdsByUser } from "@/services/progressService";
+
+export const dynamic = "force-dynamic";
+
+export default async function MePage() {
+  const session = await requireAuth();
+  const displayName = session.profile.name ?? session.email ?? session.userId;
+  const handle = session.email ? session.email.split("@")[0] : session.userId;
+  const initial = (displayName.trim()[0] ?? "?").toUpperCase();
+
+  const [myCourses, allCourses, completedIds] = await Promise.all([
+    getMyCourses(session.userId),
+    getCoursesWithLessons(),
+    getCompletedLessonIdsByUser(session.userId),
+  ]);
+
+  const acCount = completedIds.length;
+  const totalLessonsAvailable = allCourses.reduce((acc, c) => acc + c.lessons.length, 0);
+  const createdCount = myCourses.length;
+  const publishedCount = myCourses.filter((c) => c.isPublished).length;
+
+  return (
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
+      {/* Profile hero */}
+      <section
+        className="relative mb-7 overflow-hidden rounded-[20px] p-7"
+        style={{
+          background: "var(--bg-1)",
+          border: "1px solid var(--line-1)",
+        }}
+      >
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-0 top-0 h-1/2"
+          style={{
+            background:
+              "linear-gradient(135deg, oklch(0.32 0.10 var(--accent-h)), oklch(0.22 0.04 220))",
+            zIndex: 0,
+          }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-0 top-0 h-1/2"
+          style={{
+            background: "linear-gradient(180deg, transparent, var(--bg-1) 100%)",
+            zIndex: 0,
+          }}
+        />
+
+        <div className="relative z-10 flex flex-wrap items-center gap-5">
+          <div className="cm-avatar cm-avatar-xl" aria-hidden="true">
+            {initial}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h1 className="m-0 font-bold text-[26px] tracking-tight">{displayName}</h1>
+            <div className="mt-1 font-mono text-[13px]" style={{ color: "var(--text-3)" }}>
+              @{handle}
+            </div>
+            {session.email ? (
+              <div className="mt-1 text-[12.5px]" style={{ color: "var(--text-3)" }}>
+                {session.email}
+              </div>
+            ) : null}
+          </div>
+          <form action="/auth/signout" method="post">
+            <button
+              type="submit"
+              className="inline-flex items-center gap-1.5 rounded-[10px] px-3 py-2 text-[13px] transition hover:bg-[var(--bg-3)]"
+              style={{
+                background: "var(--bg-2)",
+                border: "1px solid var(--line-2)",
+                color: "var(--text-1)",
+              }}
+            >
+              <LogOut className="size-3.5" aria-hidden="true" /> サインアウト
+            </button>
+          </form>
+        </div>
+      </section>
+
+      {/* Stats */}
+      <div
+        className="mb-7 grid gap-4"
+        style={{ gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}
+      >
+        <Stat
+          icon={<CheckCircle2 className="size-3.5" aria-hidden="true" />}
+          label="クリア済みレッスン"
+          value={String(acCount)}
+          sub={totalLessonsAvailable > 0 ? `${totalLessonsAvailable} 中` : undefined}
+        />
+        <Stat
+          icon={<Flame className="size-3.5" aria-hidden="true" />}
+          label="連続日数"
+          value="0"
+          unit="日"
+        />
+        <Stat
+          icon={<Sparkles className="size-3.5" aria-hidden="true" />}
+          label="作成したコース"
+          value={String(createdCount)}
+          sub={`${publishedCount} 公開中`}
+        />
+      </div>
+
+      {/* My courses */}
+      <section>
+        <div className="mb-4 flex items-baseline justify-between">
+          <div>
+            <h2 className="m-0 font-semibold text-[18px] tracking-tight">作成したコース</h2>
+            <span className="text-xs" style={{ color: "var(--text-3)" }}>
+              あなたが作者として公開 / 管理しているコース
+            </span>
+          </div>
+          <Link href="/dashboard" className="text-[13px]" style={{ color: "var(--accent-solid)" }}>
+            管理する →
+          </Link>
+        </div>
+        {myCourses.length === 0 ? (
+          <div
+            className="rounded-[14px] px-6 py-10 text-center text-[13px]"
+            style={{
+              background: "var(--bg-1)",
+              border: "1px dashed var(--line-3)",
+              color: "var(--text-3)",
+            }}
+          >
+            まだコースを作成していません。
+            <Link
+              href="/dashboard/courses/new"
+              className="ml-1 text-[13px]"
+              style={{ color: "var(--accent-solid)" }}
+            >
+              最初のコースを作る
+            </Link>
+          </div>
+        ) : (
+          <ul
+            className="grid gap-4"
+            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
+          >
+            {myCourses.map((c) => (
+              <li key={c.id}>
+                <Link
+                  href={`/dashboard/courses/${c.id}`}
+                  className="flex h-full flex-col gap-2 rounded-[14px] p-4 transition hover:-translate-y-0.5 hover:border-[color:var(--line-3)]"
+                  style={{
+                    background: "var(--bg-1)",
+                    border: "1px solid var(--line-1)",
+                    minHeight: 140,
+                  }}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <h3
+                      className="m-0 font-semibold text-[14.5px] leading-snug tracking-tight"
+                      style={{ color: "var(--text-1)" }}
+                    >
+                      {c.title}
+                    </h3>
+                    <span
+                      className={`cm-status-pill ${
+                        c.isPublished ? "cm-status-pill-pub" : "cm-status-pill-draft"
+                      }`}
+                    >
+                      {c.isPublished ? "公開中" : "下書き"}
+                    </span>
+                  </div>
+                  {c.description ? (
+                    <p
+                      className="m-0 line-clamp-2 text-[12.5px]"
+                      style={{ color: "var(--text-3)" }}
+                    >
+                      {c.description}
+                    </p>
+                  ) : null}
+                  <div
+                    className="mt-auto flex items-center gap-3 border-t pt-2.5 font-mono text-[12px]"
+                    style={{
+                      borderColor: "var(--line-1)",
+                      color: "var(--text-3)",
+                    }}
+                  >
+                    <span>
+                      レッスン <b style={{ color: "var(--text-1)" }}>{c.lessons.length}</b>
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Stat({
+  icon,
+  label,
+  value,
+  unit,
+  sub,
+}: {
+  icon?: React.ReactNode;
+  label: string;
+  value: string;
+  unit?: string;
+  sub?: string;
+}) {
+  return (
+    <div
+      className="rounded-[14px] p-4"
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <div
+        className="mb-1.5 inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.08em]"
+        style={{ color: "var(--text-4)", fontWeight: 600 }}
+      >
+        {icon}
+        {label}
+      </div>
+      <div
+        className="font-semibold text-[28px] tracking-tight"
+        style={{ fontFamily: "var(--font-mono-family)" }}
+      >
+        {value}
+        {unit ? (
+          <span className="text-[14px]" style={{ color: "var(--text-3)" }}>
+            {unit}
+          </span>
+        ) : null}
+      </div>
+      {sub ? (
+        <div className="mt-1 font-mono text-[11.5px]" style={{ color: "var(--text-3)" }}>
+          {sub}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, BookText, CheckCircle2, Flame, Plus } from "lucide-react";
+import { ArrowRight, BookText, CheckCircle2, Plus } from "lucide-react";
 import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 import { cn } from "@/lib/utils";
@@ -76,10 +76,6 @@ export default async function Home() {
             </p>
           </div>
           <div className="flex items-center gap-3">
-            <span className="cm-chip" title="連続日数の集計は近日公開">
-              <Flame className="size-3" style={{ color: "var(--warn)" }} aria-hidden="true" />
-              連続 -- 日
-            </span>
             <span className="cm-chip cm-chip-accent">
               <CheckCircle2 className="size-3" aria-hidden="true" />
               {totalDone} クリア
@@ -185,48 +181,6 @@ export default async function Home() {
             })}
           </ul>
         )}
-      </section>
-
-      {/* Activity heatmap placeholder */}
-      <section className="mt-10">
-        <div className="mb-4">
-          <h2 className="m-0 font-semibold text-[18px] tracking-tight">学習ヒートマップ</h2>
-          <span className="text-xs" style={{ color: "var(--text-3)" }}>
-            過去52週間の活動 (準備中)
-          </span>
-        </div>
-        <div
-          className="overflow-x-auto rounded-[14px]"
-          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-        >
-          <div
-            className="grid gap-[3px] p-4"
-            style={{
-              gridAutoFlow: "column",
-              gridTemplateRows: "repeat(7, 10px)",
-              width: "max-content",
-            }}
-          >
-            {Array.from({ length: 7 * 52 }, (_, i) => `cell-${i}`).map((id) => (
-              <div key={id} className="cm-heat-cell" />
-            ))}
-          </div>
-          <div
-            className="flex items-center justify-between border-t px-4 py-2.5 text-[12px]"
-            style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
-          >
-            <span>活動データは近日公開</span>
-            <div className="flex items-center gap-1 text-[11px]" style={{ color: "var(--text-4)" }}>
-              少ない
-              <span className="cm-heat-cell" />
-              <span className="cm-heat-cell cm-heat-1" />
-              <span className="cm-heat-cell cm-heat-2" />
-              <span className="cm-heat-cell cm-heat-3" />
-              <span className="cm-heat-cell cm-heat-4" />
-              多い
-            </div>
-          </div>
-        </div>
       </section>
     </div>
   );

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -1,10 +1,31 @@
+import { ArrowRight, BookText, CheckCircle2, Flame, Plus } from "lucide-react";
 import Link from "next/link";
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { requireAuth } from "@/lib/auth";
+import { cn } from "@/lib/utils";
 import { getCoursesWithLessons } from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
 
 export const dynamic = "force-dynamic";
+
+const COVER_VARIANTS = [
+  "cm-cover-1",
+  "cm-cover-2",
+  "cm-cover-3",
+  "cm-cover-4",
+  "cm-cover-5",
+  "cm-cover-6",
+] as const;
+
+function coverFor(index: number) {
+  return COVER_VARIANTS[index % COVER_VARIANTS.length];
+}
+
+function glyphFor(title: string) {
+  const trimmed = title.trim();
+  if (!trimmed) return "TS";
+  const chars = Array.from(trimmed);
+  return chars.slice(0, 2).join("").toUpperCase();
+}
 
 export default async function Home() {
   const session = await requireAuth();
@@ -14,49 +35,221 @@ export default async function Home() {
   ]);
 
   const completedIds = new Set(completed);
+  const totalDone = courses.reduce(
+    (acc, c) => acc + c.lessons.filter((l) => completedIds.has(l.id)).length,
+    0,
+  );
+  const firstName = (session.profile.name ?? session.email ?? "学習者").split(/[\s@]/)[0];
 
   return (
-    <div className="mx-auto max-w-3xl flex-1 px-6 py-16">
-      <header className="mb-12">
-        <h1 className="text-4xl font-bold tracking-tight">codelearn</h1>
-        <p className="mt-3 text-lg text-zinc-600 dark:text-zinc-400">
-          ブラウザで TypeScript を学ぶ。手を動かしながら進めよう。
-        </p>
-      </header>
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
+      {/* Hero */}
+      <section
+        className="cm-grain relative overflow-hidden rounded-[20px] p-7"
+        style={{
+          background: "linear-gradient(135deg, var(--bg-1), var(--bg-2))",
+          border: "1px solid var(--line-1)",
+          isolation: "isolate",
+        }}
+      >
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute"
+          style={{
+            inset: "-80px -80px auto auto",
+            width: 420,
+            height: 420,
+            background:
+              "radial-gradient(circle, oklch(0.78 var(--accent-c) var(--accent-h) / 0.35), transparent 65%)",
+            filter: "blur(30px)",
+            zIndex: 0,
+          }}
+        />
+        <div className="relative z-10 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <div className="cm-label mb-1">ようこそ</div>
+            <h1 className="m-0 font-semibold text-[22px] tracking-tight">
+              おかえりなさい、{firstName}さん
+            </h1>
+            <p className="mt-2 text-[13px]" style={{ color: "var(--text-3)" }}>
+              ブラウザで TypeScript を学ぶ。手を動かしながら進めよう。
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="cm-chip">
+              <Flame className="size-3" style={{ color: "var(--warn)" }} aria-hidden="true" />
+              0日連続
+            </span>
+            <span className="cm-chip cm-chip-accent">
+              <CheckCircle2 className="size-3" aria-hidden="true" />
+              {totalDone} クリア
+            </span>
+            <Link
+              href="/dashboard/courses/new"
+              className="inline-flex items-center gap-2 rounded-[10px] px-4 py-2 font-semibold text-[13px] transition"
+              style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
+            >
+              <Plus className="size-3.5" aria-hidden="true" />
+              コースを作る
+            </Link>
+          </div>
+        </div>
+      </section>
 
-      {courses.length === 0 ? (
-        <p className="text-zinc-500">
-          まだコースがありません。
-          <code className="rounded bg-zinc-100 px-2 py-0.5 text-sm dark:bg-zinc-800">
-            npm run db:seed
-          </code>{" "}
-          を実行してください。
-        </p>
-      ) : (
-        <ul className="space-y-4">
-          {courses.map((c) => {
-            const total = c.lessons.length;
-            const done = c.lessons.filter((l) => completedIds.has(l.id)).length;
-            return (
-              <li key={c.id}>
-                <Link className="block transition hover:opacity-80" href={`/courses/${c.slug}`}>
-                  <Card>
-                    <CardHeader>
-                      <div className="flex items-center justify-between gap-3">
-                        <CardTitle className="text-xl">{c.title}</CardTitle>
-                        <span className="shrink-0 text-sm text-muted-foreground">
-                          {done} / {total} クリア
+      {/* Courses */}
+      <section className="mt-10">
+        <div className="mb-4 flex items-baseline justify-between">
+          <div>
+            <h2 className="m-0 font-semibold text-[18px] tracking-tight">コース一覧</h2>
+            <span className="text-xs" style={{ color: "var(--text-3)" }}>
+              公開されている TypeScript コース
+            </span>
+          </div>
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center gap-1 text-[13px] transition hover:text-[var(--accent-solid)]"
+            style={{ color: "var(--text-2)" }}
+          >
+            管理 <ArrowRight className="size-3" aria-hidden="true" />
+          </Link>
+        </div>
+
+        {courses.length === 0 ? (
+          <EmptyCourses />
+        ) : (
+          <ul
+            className="grid gap-4"
+            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
+          >
+            {courses.map((c, idx) => {
+              const total = c.lessons.length;
+              const done = c.lessons.filter((l) => completedIds.has(l.id)).length;
+              const pct = total === 0 ? 0 : Math.round((done / total) * 100);
+              return (
+                <li key={c.id}>
+                  <Link
+                    href={`/courses/${c.slug}`}
+                    className={cn(
+                      "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
+                      "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
+                    )}
+                    style={{
+                      background: "var(--bg-1)",
+                      border: "1px solid var(--line-1)",
+                    }}
+                  >
+                    <div className={cn("cm-cover", coverFor(idx))}>
+                      <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
+                        <span className="cm-diff-badge cm-diff-1">初級</span>
+                      </div>
+                      <span className="cm-cover-glyph" aria-hidden="true">
+                        {glyphFor(c.title)}
+                      </span>
+                    </div>
+                    <div className="flex flex-1 flex-col gap-2.5 p-4">
+                      <h3
+                        className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
+                        style={{ color: "var(--text-1)" }}
+                      >
+                        {c.title}
+                      </h3>
+                      {c.description ? (
+                        <p
+                          className="m-0 line-clamp-2 text-[12.5px]"
+                          style={{ color: "var(--text-3)" }}
+                        >
+                          {c.description}
+                        </p>
+                      ) : null}
+                      <div className="mt-auto flex items-center gap-3">
+                        <div className="cm-progress flex-1">
+                          <span style={{ width: `${pct}%` }} />
+                        </div>
+                        <span className="cm-mono" style={{ color: "var(--text-3)" }}>
+                          {done}/{total}
                         </span>
                       </div>
-                      <CardDescription>{c.description}</CardDescription>
-                    </CardHeader>
-                  </Card>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      )}
+                      <div
+                        className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
+                        style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          <BookText className="size-3" aria-hidden="true" />
+                          <b style={{ color: "var(--text-1)" }}>{total}</b> レッスン
+                        </span>
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {/* Activity heatmap placeholder */}
+      <section className="mt-10">
+        <div className="mb-4">
+          <h2 className="m-0 font-semibold text-[18px] tracking-tight">学習ヒートマップ</h2>
+          <span className="text-xs" style={{ color: "var(--text-3)" }}>
+            過去52週間の活動 (準備中)
+          </span>
+        </div>
+        <div
+          className="overflow-x-auto rounded-[14px]"
+          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+        >
+          <div
+            className="grid gap-[3px] p-4"
+            style={{
+              gridAutoFlow: "column",
+              gridTemplateRows: "repeat(7, 10px)",
+              width: "max-content",
+            }}
+          >
+            {Array.from({ length: 7 * 52 }, (_, i) => `cell-${i}`).map((id) => (
+              <div key={id} className="cm-heat-cell" />
+            ))}
+          </div>
+          <div
+            className="flex items-center justify-between border-t px-4 py-2.5 text-[12px]"
+            style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
+          >
+            <span>活動データは近日公開</span>
+            <div className="flex items-center gap-1 text-[11px]" style={{ color: "var(--text-4)" }}>
+              少ない
+              <span className="cm-heat-cell" />
+              <span className="cm-heat-cell cm-heat-1" />
+              <span className="cm-heat-cell cm-heat-2" />
+              <span className="cm-heat-cell cm-heat-3" />
+              <span className="cm-heat-cell cm-heat-4" />
+              多い
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function EmptyCourses() {
+  return (
+    <div
+      className="rounded-[14px] px-8 py-12 text-center text-[13px]"
+      style={{
+        background: "var(--bg-1)",
+        border: "1px dashed var(--line-3)",
+        color: "var(--text-3)",
+      }}
+    >
+      まだコースがありません。
+      <code
+        className="mx-1 rounded px-2 py-0.5 text-[12px]"
+        style={{ background: "var(--bg-2)", color: "var(--accent-solid)" }}
+      >
+        npm run db:seed
+      </code>
+      を実行してください。
     </div>
   );
 }

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -76,9 +76,9 @@ export default async function Home() {
             </p>
           </div>
           <div className="flex items-center gap-3">
-            <span className="cm-chip">
+            <span className="cm-chip" title="連続日数の集計は近日公開">
               <Flame className="size-3" style={{ color: "var(--warn)" }} aria-hidden="true" />
-              0日連続
+              連続 -- 日
             </span>
             <span className="cm-chip cm-chip-accent">
               <CheckCircle2 className="size-3" aria-hidden="true" />

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, BookText, CheckCircle2, Plus } from "lucide-react";
+import { BookText } from "lucide-react";
 import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 import { cn } from "@/lib/utils";
@@ -35,79 +35,15 @@ export default async function Home() {
   ]);
 
   const completedIds = new Set(completed);
-  const totalDone = courses.reduce(
-    (acc, c) => acc + c.lessons.filter((l) => completedIds.has(l.id)).length,
-    0,
-  );
-  const firstName = (session.profile.name ?? session.email ?? "学習者").split(/[\s@]/)[0];
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
-      {/* Hero */}
-      <section
-        className="cm-grain relative overflow-hidden rounded-[20px] p-7"
-        style={{
-          background: "linear-gradient(135deg, var(--bg-1), var(--bg-2))",
-          border: "1px solid var(--line-1)",
-          isolation: "isolate",
-        }}
-      >
-        <span
-          aria-hidden="true"
-          className="pointer-events-none absolute"
-          style={{
-            inset: "-80px -80px auto auto",
-            width: 420,
-            height: 420,
-            background:
-              "radial-gradient(circle, oklch(0.78 var(--accent-c) var(--accent-h) / 0.35), transparent 65%)",
-            filter: "blur(30px)",
-            zIndex: 0,
-          }}
-        />
-        <div className="relative z-10 flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <div className="cm-label mb-1">ようこそ</div>
-            <h1 className="m-0 font-semibold text-[22px] tracking-tight">
-              おかえりなさい、{firstName}さん
-            </h1>
-            <p className="mt-2 text-[13px]" style={{ color: "var(--text-3)" }}>
-              ブラウザで TypeScript を学ぶ。手を動かしながら進めよう。
-            </p>
-          </div>
-          <div className="flex items-center gap-3">
-            <span className="cm-chip cm-chip-accent">
-              <CheckCircle2 className="size-3" aria-hidden="true" />
-              {totalDone} クリア
-            </span>
-            <Link
-              href="/dashboard/courses/new"
-              className="inline-flex items-center gap-2 rounded-[10px] px-4 py-2 font-semibold text-[13px] transition"
-              style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
-            >
-              <Plus className="size-3.5" aria-hidden="true" />
-              コースを作る
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Courses */}
-      <section className="mt-10">
-        <div className="mb-4 flex items-baseline justify-between">
-          <div>
-            <h2 className="m-0 font-semibold text-[18px] tracking-tight">コース一覧</h2>
-            <span className="text-xs" style={{ color: "var(--text-3)" }}>
-              公開されている TypeScript コース
-            </span>
-          </div>
-          <Link
-            href="/dashboard"
-            className="inline-flex items-center gap-1 text-[13px] transition hover:text-[var(--accent-solid)]"
-            style={{ color: "var(--text-2)" }}
-          >
-            管理 <ArrowRight className="size-3" aria-hidden="true" />
-          </Link>
+      <section>
+        <div className="mb-4">
+          <h1 className="m-0 font-semibold text-[22px] tracking-tight">コース一覧</h1>
+          <span className="text-xs" style={{ color: "var(--text-3)" }}>
+            公開されている TypeScript コース
+          </span>
         </div>
 
         {courses.length === 0 ? (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,9 +7,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-sans: var(--font-sans-family);
+  --font-mono: var(--font-mono-family);
+  --font-heading: var(--font-sans-family);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -48,73 +48,143 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+/* =======================================================
+   codeMaker tokens — dark-only, warm neutrals + violet accent
+   ======================================================= */
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
+  /* --- Neutrals (slight warm tint, very low chroma) --- */
+  --bg-0: oklch(0.18 0.008 280);
+  --bg-1: oklch(0.215 0.01 280);
+  --bg-2: oklch(0.25 0.012 280);
+  --bg-3: oklch(0.3 0.014 280);
+  --bg-code: oklch(0.15 0.008 280);
+
+  --line-1: oklch(0.3 0.012 280 / 0.8);
+  --line-2: oklch(0.38 0.014 280 / 0.9);
+  --line-3: oklch(0.48 0.014 280);
+
+  --text-1: oklch(0.97 0.005 280);
+  --text-2: oklch(0.8 0.008 280);
+  --text-3: oklch(0.64 0.01 280);
+  --text-4: oklch(0.5 0.01 280);
+
+  /* --- Accent (violet) --- */
+  --accent-h: 295;
+  --accent-c: 0.18;
+  --accent-solid: oklch(0.78 var(--accent-c) var(--accent-h));
+  --accent-2: oklch(0.68 var(--accent-c) var(--accent-h));
+  --accent-3: oklch(0.55 var(--accent-c) var(--accent-h));
+  --accent-soft: oklch(0.78 var(--accent-c) var(--accent-h) / 0.14);
+  --accent-line: oklch(0.78 var(--accent-c) var(--accent-h) / 0.4);
+  --accent-ink: oklch(0.16 0.02 var(--accent-h));
+
+  /* --- Semantic status colors --- */
+  --ok: oklch(0.82 0.16 145);
+  --ok-soft: oklch(0.82 0.16 145 / 0.14);
+  --warn: oklch(0.84 0.15 85);
+  --warn-soft: oklch(0.84 0.15 85 / 0.14);
+  --err: oklch(0.72 0.19 25);
+  --err-soft: oklch(0.72 0.19 25 / 0.14);
+  --info: oklch(0.78 0.14 230);
+  --info-soft: oklch(0.78 0.14 230 / 0.14);
+  --re: oklch(0.72 0.16 310);
+  --re-soft: oklch(0.72 0.16 310 / 0.14);
+
+  /* Difficulty (3 levels) */
+  --diff-1: oklch(0.82 0.16 145);
+  --diff-2: oklch(0.84 0.15 85);
+  --diff-3: oklch(0.72 0.19 25);
+
+  /* --- Radii --- */
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 20px;
+  --r-pill: 999px;
+
+  /* --- Shadows --- */
+  --shadow-1: 0 1px 0 0 oklch(1 0 0 / 0.03) inset, 0 1px 2px oklch(0 0 0 / 0.4);
+  --shadow-2: 0 1px 0 0 oklch(1 0 0 / 0.04) inset, 0 8px 24px oklch(0 0 0 / 0.45);
+  --shadow-pop: 0 12px 36px oklch(0 0 0 / 0.55), 0 0 0 1px var(--line-2);
+  --glow-accent:
+    0 0 0 1px var(--accent-line), 0 6px 24px oklch(0.78 var(--accent-c) var(--accent-h) / 0.25);
+
+  /* --- Type stacks (composed with next/font variables) --- */
+  --font-sans-family:
+    var(--font-inter), "Noto Sans JP", var(--font-noto-jp), system-ui, -apple-system, "Segoe UI",
+    Roboto, sans-serif;
+  --font-mono-family:
+    var(--font-jetbrains-mono), ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+
+  /* --- shadcn variable remapping (so existing shadcn components pick up codeMaker palette) --- */
+  --background: var(--bg-0);
+  --foreground: var(--text-1);
+  --card: var(--bg-1);
+  --card-foreground: var(--text-1);
+  --popover: var(--bg-1);
+  --popover-foreground: var(--text-1);
+  --primary: var(--accent-solid);
+  --primary-foreground: var(--accent-ink);
+  --secondary: var(--bg-2);
+  --secondary-foreground: var(--text-1);
+  --muted: var(--bg-2);
+  --muted-foreground: var(--text-3);
+  --accent: var(--bg-2);
+  --accent-foreground: var(--text-1);
+  --destructive: var(--err);
+  --border: var(--line-1);
+  --input: var(--line-2);
+  --ring: var(--accent-solid);
+  --chart-1: var(--accent-solid);
+  --chart-2: var(--info);
+  --chart-3: var(--ok);
+  --chart-4: var(--warn);
+  --chart-5: var(--re);
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: var(--bg-1);
+  --sidebar-foreground: var(--text-1);
+  --sidebar-primary: var(--accent-solid);
+  --sidebar-primary-foreground: var(--accent-ink);
+  --sidebar-accent: var(--bg-2);
+  --sidebar-accent-foreground: var(--text-1);
+  --sidebar-border: var(--line-1);
+  --sidebar-ring: var(--accent-solid);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* Dark-fixed project: same values (palette is dark-only). */
+  --background: var(--bg-0);
+  --foreground: var(--text-1);
+  --card: var(--bg-1);
+  --card-foreground: var(--text-1);
+  --popover: var(--bg-1);
+  --popover-foreground: var(--text-1);
+  --primary: var(--accent-solid);
+  --primary-foreground: var(--accent-ink);
+  --secondary: var(--bg-2);
+  --secondary-foreground: var(--text-1);
+  --muted: var(--bg-2);
+  --muted-foreground: var(--text-3);
+  --accent: var(--bg-2);
+  --accent-foreground: var(--text-1);
+  --destructive: var(--err);
+  --border: var(--line-1);
+  --input: var(--line-2);
+  --ring: var(--accent-solid);
+  --chart-1: var(--accent-solid);
+  --chart-2: var(--info);
+  --chart-3: var(--ok);
+  --chart-4: var(--warn);
+  --chart-5: var(--re);
+  --sidebar: var(--bg-1);
+  --sidebar-foreground: var(--text-1);
+  --sidebar-primary: var(--accent-solid);
+  --sidebar-primary-foreground: var(--accent-ink);
+  --sidebar-accent: var(--bg-2);
+  --sidebar-accent-foreground: var(--text-1);
+  --sidebar-border: var(--line-1);
+  --sidebar-ring: var(--accent-solid);
 }
 
 @layer base {
@@ -123,8 +193,369 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-feature-settings: "cv11", "ss01";
   }
   html {
     @apply font-sans;
+  }
+
+  ::selection {
+    background: var(--accent-soft);
+    color: var(--text-1);
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--bg-3);
+    border-radius: 10px;
+    border: 2px solid var(--bg-0);
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--line-3);
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--accent-solid);
+    outline-offset: 2px;
+    border-radius: var(--r-sm);
+  }
+}
+
+/* =======================================================
+   codeMaker utility atoms (consumed by bespoke layout pieces —
+   shadcn primitives are still preferred for buttons / cards).
+   ======================================================= */
+@layer components {
+  .cm-surface {
+    background: var(--bg-1);
+    border: 1px solid var(--line-1);
+    border-radius: var(--r-lg);
+  }
+
+  .cm-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    border-radius: var(--r-pill);
+    background: var(--bg-3);
+    color: var(--text-2);
+    font-size: 12px;
+    font-weight: 500;
+    border: 1px solid var(--line-1);
+    white-space: nowrap;
+  }
+  .cm-chip-accent {
+    background: var(--accent-soft);
+    color: var(--accent-solid);
+    border-color: var(--accent-line);
+  }
+
+  .cm-kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    font-family: var(--font-mono-family);
+    font-size: 11px;
+    color: var(--text-2);
+    background: var(--bg-3);
+    border: 1px solid var(--line-2);
+    border-bottom-width: 2px;
+    border-radius: var(--r-xs);
+  }
+
+  .cm-diff-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 9px;
+    border-radius: var(--r-pill);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    border: 1px solid currentColor;
+  }
+  .cm-diff-badge::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+  .cm-diff-1 {
+    color: var(--diff-1);
+    background: oklch(0.82 0.16 145 / 0.12);
+  }
+  .cm-diff-2 {
+    color: var(--diff-2);
+    background: oklch(0.84 0.15 85 / 0.12);
+  }
+  .cm-diff-3 {
+    color: var(--diff-3);
+    background: oklch(0.72 0.19 25 / 0.12);
+  }
+
+  .cm-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+  }
+  .cm-status-ac {
+    background: var(--ok);
+    box-shadow: 0 0 0 3px var(--ok-soft);
+  }
+  .cm-status-wa {
+    background: var(--err);
+    box-shadow: 0 0 0 3px var(--err-soft);
+  }
+  .cm-status-try {
+    background: var(--warn);
+    box-shadow: 0 0 0 3px var(--warn-soft);
+  }
+  .cm-status-none {
+    background: var(--line-3);
+  }
+
+  .cm-progress {
+    position: relative;
+    height: 6px;
+    border-radius: var(--r-pill);
+    background: var(--bg-3);
+    overflow: hidden;
+  }
+  .cm-progress > span {
+    position: absolute;
+    inset: 0 auto 0 0;
+    background: linear-gradient(90deg, var(--accent-3), var(--accent-solid));
+    border-radius: var(--r-pill);
+    transition: width 0.4s ease;
+  }
+
+  .cm-segment {
+    display: inline-flex;
+    padding: 3px;
+    background: var(--bg-2);
+    border: 1px solid var(--line-1);
+    border-radius: var(--r-md);
+    gap: 2px;
+  }
+  .cm-segment button {
+    padding: 5px 12px;
+    border-radius: var(--r-sm);
+    font-size: 12px;
+    color: var(--text-3);
+    font-weight: 500;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+  }
+  .cm-segment button:hover {
+    color: var(--text-1);
+  }
+  .cm-segment button[aria-pressed="true"] {
+    background: var(--bg-0);
+    color: var(--text-1);
+    box-shadow: var(--shadow-1);
+  }
+
+  .cm-heat-cell {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: var(--bg-2);
+  }
+  .cm-heat-1 {
+    background: oklch(0.78 var(--accent-c) var(--accent-h) / 0.2);
+  }
+  .cm-heat-2 {
+    background: oklch(0.78 var(--accent-c) var(--accent-h) / 0.38);
+  }
+  .cm-heat-3 {
+    background: oklch(0.78 var(--accent-c) var(--accent-h) / 0.6);
+  }
+  .cm-heat-4 {
+    background: oklch(0.78 var(--accent-c) var(--accent-h) / 0.85);
+  }
+
+  .cm-status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 10px;
+    border-radius: var(--r-pill);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .cm-status-pill-draft {
+    background: var(--warn-soft);
+    color: var(--warn);
+  }
+  .cm-status-pill-pub {
+    background: var(--ok-soft);
+    color: var(--ok);
+  }
+
+  .cm-cover {
+    position: relative;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    border-radius: var(--r-md);
+  }
+  .cm-cover::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 55%, oklch(0 0 0 / 0.5));
+  }
+  .cm-cover-glyph {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    font-family: var(--font-mono-family);
+    font-size: 48px;
+    font-weight: 700;
+    color: oklch(1 0 0 / 0.85);
+    letter-spacing: -0.04em;
+    mix-blend-mode: overlay;
+  }
+  .cm-cover-1 {
+    background:
+      linear-gradient(135deg, oklch(0.4 0.12 300), oklch(0.28 0.1 260)),
+      repeating-linear-gradient(45deg, transparent 0 8px, oklch(1 0 0 / 0.04) 8px 9px);
+    background-blend-mode: overlay;
+  }
+  .cm-cover-2 {
+    background: linear-gradient(135deg, oklch(0.38 0.1 150), oklch(0.25 0.06 220));
+  }
+  .cm-cover-3 {
+    background: linear-gradient(135deg, oklch(0.42 0.11 30), oklch(0.3 0.08 320));
+  }
+  .cm-cover-4 {
+    background: linear-gradient(135deg, oklch(0.36 0.1 220), oklch(0.24 0.08 280));
+  }
+  .cm-cover-5 {
+    background: linear-gradient(135deg, oklch(0.4 0.1 85), oklch(0.26 0.06 180));
+  }
+  .cm-cover-6 {
+    background: linear-gradient(135deg, oklch(0.38 0.12 330), oklch(0.22 0.06 260));
+  }
+
+  .cm-grain {
+    position: relative;
+    overflow: hidden;
+  }
+  .cm-grain::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image:
+      radial-gradient(
+        circle at 20% 10%,
+        oklch(0.78 var(--accent-c) var(--accent-h) / 0.22),
+        transparent 55%
+      ),
+      radial-gradient(circle at 80% 90%, oklch(0.78 0.14 230 / 0.14), transparent 50%);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .cm-brand-mark {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, var(--accent-solid), oklch(0.68 0.16 250));
+    display: grid;
+    place-items: center;
+    font-family: var(--font-mono-family);
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--accent-ink);
+    box-shadow: var(--shadow-1);
+  }
+
+  .cm-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, oklch(0.68 0.14 30), oklch(0.72 0.16 320));
+    display: grid;
+    place-items: center;
+    color: var(--accent-ink);
+    font-weight: 700;
+    font-size: 12px;
+    flex-shrink: 0;
+    border: 2px solid var(--bg-1);
+  }
+  .cm-avatar-sm {
+    width: 22px;
+    height: 22px;
+    font-size: 10px;
+    border-width: 1px;
+  }
+  .cm-avatar-lg {
+    width: 64px;
+    height: 64px;
+    font-size: 22px;
+    border-width: 3px;
+  }
+  .cm-avatar-xl {
+    width: 96px;
+    height: 96px;
+    font-size: 32px;
+    border-width: 4px;
+  }
+
+  .cm-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-4);
+    font-weight: 600;
+  }
+
+  .cm-mono {
+    font-family: var(--font-mono-family);
+    font-size: 12px;
+  }
+
+  @keyframes cm-pulse-dot {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.45;
+    }
+  }
+  .cm-pulse {
+    animation: cm-pulse-dot 1.6s ease-in-out infinite;
+  }
+
+  @keyframes cm-route-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .cm-route-enter {
+    animation: cm-route-in 0.22s ease-out both;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -152,6 +152,7 @@
   --sidebar-ring: var(--accent-solid);
 }
 
+/* dark-only の冗長フォールバック。class なしでも同じ値が効く */
 .dark {
   /* Dark-fixed project: same values (palette is dark-only). */
   --background: var(--bg-0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,28 +1,37 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono, Noto_Sans_JP } from "next/font/google";
 import { SwrProvider } from "@/components/providers/SwrProvider";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
+  display: "swap",
+});
+
+const notoSansJp = Noto_Sans_JP({
+  variable: "--font-noto-jp",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
-  title: "codelearn — learn TypeScript in your browser",
-  description: "Progate-style TypeScript learning platform",
+  title: "codeMaker — ブラウザで TypeScript を学ぶ",
+  description: "モノづくりで学ぶ TypeScript 学習プラットフォーム",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html
       lang="ja"
-      className={`dark ${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`dark ${inter.variable} ${jetbrainsMono.variable} ${notoSansJp.variable} h-full antialiased`}
       style={{ colorScheme: "dark" }}
       suppressHydrationWarning
     >

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,8 +12,21 @@ export default async function LoginPage({ searchParams }: PageProps<"/login">) {
   return (
     <div className="mx-auto flex min-h-screen w-full max-w-md flex-1 flex-col items-center justify-center px-6 py-16">
       <div className="w-full">
-        <h1 className="text-3xl font-bold tracking-tight">codelearn</h1>
-        <p className="mt-2 text-sm text-zinc-400">サインインして学習を続けよう。</p>
+        <div className="flex items-center gap-2.5">
+          <span className="cm-brand-mark" aria-hidden="true">
+            {"</>"}
+          </span>
+          <h1 className="m-0 font-bold text-[26px] tracking-tight">codeMaker</h1>
+          <span
+            className="ml-0.5 font-mono font-normal text-[11px]"
+            style={{ color: "var(--text-3)" }}
+          >
+            beta
+          </span>
+        </div>
+        <p className="mt-3 text-sm" style={{ color: "var(--text-3)" }}>
+          サインインして学習を続けよう。
+        </p>
 
         {error ? (
           <p className="mt-6 rounded-md border border-red-900 bg-red-950/40 px-3 py-2 text-sm text-red-200">

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -49,6 +49,20 @@ export class CourseRepository extends BaseRepository {
     });
   }
 
+  async findAllPublishedByNewest(): Promise<CourseWithLessonIds[]> {
+    return this.client.course.findMany({
+      where: { isPublished: true },
+      orderBy: { createdAt: "desc" },
+      include: {
+        lessons: {
+          where: { isPublished: true },
+          select: { id: true },
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+  }
+
   async findBySlugWithLessons(slug: string): Promise<CourseWithLessons | null> {
     return this.client.course.findUnique({
       where: { slug },

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -9,6 +9,17 @@ export type CourseWithLessons = Prisma.CourseGetPayload<{
 
 export type CourseWithLessonIds = Course & { lessons: Pick<Lesson, "id">[] };
 
+export type CourseAuthor = {
+  id: string;
+  email: string | null;
+  name: string | null;
+  avatarUrl: string | null;
+};
+
+export type CourseWithLessonsAndAuthor = CourseWithLessonIds & {
+  author: CourseAuthor | null;
+};
+
 export type CreateCourseInput = {
   slug: string;
   title: string;
@@ -49,7 +60,7 @@ export class CourseRepository extends BaseRepository {
     });
   }
 
-  async findAllPublishedByNewest(): Promise<CourseWithLessonIds[]> {
+  async findAllPublishedByNewest(): Promise<CourseWithLessonsAndAuthor[]> {
     return this.client.course.findMany({
       where: { isPublished: true },
       orderBy: { createdAt: "desc" },
@@ -58,6 +69,9 @@ export class CourseRepository extends BaseRepository {
           where: { isPublished: true },
           select: { id: true },
           orderBy: { order: "asc" },
+        },
+        author: {
+          select: { id: true, email: true, name: true, avatarUrl: true },
         },
       },
     });

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -11,8 +11,10 @@ export const profileRepository = new ProfileRepository();
 export const progressRepository = new ProgressRepository();
 
 export type {
+  CourseAuthor,
   CourseWithLessonIds,
   CourseWithLessons,
+  CourseWithLessonsAndAuthor,
   CreateCourseInput,
   UpdateCourseInput,
 } from "./course.repository";

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -25,6 +25,20 @@ export async function getCoursesWithLessons(
   }
 }
 
+export async function getPublishedCoursesByNewest(
+  repository: CourseRepository = courseRepository,
+): Promise<CourseWithLessonIds[]> {
+  logInfo("courseService.getPublishedCoursesByNewest.start");
+  try {
+    const result = await repository.findAllPublishedByNewest();
+    logInfo("courseService.getPublishedCoursesByNewest.success", { count: result.length });
+    return result;
+  } catch (error) {
+    logError("courseService.getPublishedCoursesByNewest.error", undefined, error);
+    throw handleUnknownError(error);
+  }
+}
+
 export async function getCourseBySlug(
   slug: string,
   repository: CourseRepository = courseRepository,

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -7,6 +7,7 @@ import {
   type CourseRepository,
   type CourseWithLessonIds,
   type CourseWithLessons,
+  type CourseWithLessonsAndAuthor,
   courseRepository,
 } from "@/repositories";
 import { ensureAuthorOwnsCourse } from "./authorGuard";
@@ -27,7 +28,7 @@ export async function getCoursesWithLessons(
 
 export async function getPublishedCoursesByNewest(
   repository: CourseRepository = courseRepository,
-): Promise<CourseWithLessonIds[]> {
+): Promise<CourseWithLessonsAndAuthor[]> {
   logInfo("courseService.getPublishedCoursesByNewest.start");
   try {
     const result = await repository.findAllPublishedByNewest();


### PR DESCRIPTION
## Summary

Claude Design で生成したプロトタイプ (codeMaker/) を Next.js + shadcn/ui + Tailwind v4 に移植し、UI の見た目とトンマナを全面的に寄せた PR。機能 (認証 / DB / Monaco 実行 / UGC CRUD) は既存のまま変更していない。

- warm-neutrals + violet-accent のダークパレットを globals.css に実装し、既存の shadcn CSS variables を codeMaker トークンに再マッピング
- Inter / JetBrains Mono / Noto Sans JP を next/font/google で導入
- TopBar を追加 (brand / 検索 / ナビ / 通知 / avatar)、レッスン詳細は full-bleed のため TopBarSwitcher でスキップ
- Home / Collection / Problem / Create / Me の 5 画面をレイアウトから刷新
- ブランド表記は UI 上のみ codeMaker に変更 (repo 名・package 名は codelearn のまま)

## 既存機能を壊していないチェックリスト

- [x] Supabase 認証と requireAuth は触っていない
- [x] Monaco Editor + useLessonRunner は props / 呼び出し方を維持
- [x] Progress 保存 (completeLessonAction) のロジックは未変更
- [x] Dashboard の Course / Lesson CRUD (publish toggle / delete) は handler を再利用
- [x] npm run check (biome) pass
- [x] npm run build pass

## スコープ外 (別 issue で対応)

- /explore, /profile/[userId] の実ページ (TopBar のリンクだけ張っている)
- 通知 bell の実装
- ヒートマップの実データ集計 (現在は固定プレースホルダ)
- judge 判定の多段階可視化 (AC / WA 2 値のみ、TLE / RE などは未実装)
- difficulty 列 (Prisma schema に無いので全レッスン「初級」固定表示)
- 連続日数・AC 数の時系列計算

## Test plan

- [ ] /login でサインイン
- [ ] / で新しいコース一覧 UI が表示される / 進捗バーが埋まる
- [ ] /courses/ts-intro で Collection 風レイアウトが表示される
- [ ] /courses/ts-intro/lessons/hello-world で Problem 風レイアウトが表示され、実行ボタンが動いて期待出力一致でクリア判定が出る
- [ ] /dashboard で Create 風カード一覧 / 新規コース作成が動く
- [ ] /me で自分の profile + サインアウトが動作する
- [ ] TopBar のリンクが全部動く (/explore は 404 で OK)
- [ ] ダークモード固定、キーボードナビゲーション可

🤖 Generated with [Claude Code](https://claude.com/claude-code)