### PR TITLE
feat(ui): Issue #53 UI 残作業対応

### DIFF
--- a/src/app/(protected)/_components/BrowseFilterPanel.tsx
+++ b/src/app/(protected)/_components/BrowseFilterPanel.tsx
@@ -1,0 +1,137 @@
+const DIFFICULTY_FILTERS = [
+  { key: "beginner", label: "初級" },
+  { key: "intermediate", label: "中級" },
+  { key: "advanced", label: "上級" },
+] as const;
+
+const TAG_FILTERS = ["TypeScript", "基礎", "型", "関数", "配列", "オブジェクト", "入門"] as const;
+
+const LANGUAGE_FILTERS = [
+  { key: "typescript", label: "TypeScript", active: true },
+  { key: "javascript", label: "JavaScript", active: false },
+  { key: "python", label: "Python", active: false },
+] as const;
+
+type Props = {
+  /**
+   * Accessible label describing the current filter context
+   * (e.g. "フィルタ (学ぶ)"). The filters themselves are disabled preview UI.
+   */
+  ariaLabel?: string;
+};
+
+export function BrowseFilterPanel({ ariaLabel = "フィルタ (UI プレビュー)" }: Props) {
+  return (
+    <aside
+      className="h-max rounded-[14px] p-4 md:sticky md:top-20"
+      style={{
+        background: "var(--bg-1)",
+        border: "1px solid var(--line-1)",
+      }}
+      aria-label={ariaLabel}
+    >
+      <FilterGroup title="難易度">
+        <ul className="space-y-0.5">
+          {DIFFICULTY_FILTERS.map((d) => (
+            <li key={d.key}>
+              <CheckRow label={d.label} count={0} />
+            </li>
+          ))}
+        </ul>
+      </FilterGroup>
+
+      <FilterGroup title="タグ">
+        <div className="flex flex-wrap gap-1.5">
+          {TAG_FILTERS.map((tag) => (
+            <TagChip key={tag} label={tag} />
+          ))}
+        </div>
+      </FilterGroup>
+
+      <FilterGroup title="対応言語">
+        <ul className="space-y-0.5">
+          {LANGUAGE_FILTERS.map((l) => (
+            <li key={l.key}>
+              <CheckRow label={l.label} checked={l.active} />
+            </li>
+          ))}
+        </ul>
+      </FilterGroup>
+
+      <button
+        type="button"
+        disabled
+        aria-disabled="true"
+        className="mt-2 inline-flex w-full cursor-not-allowed items-center justify-center rounded-[6px] px-2.5 py-1.5 text-[12px] opacity-60"
+        style={{ color: "var(--text-2)" }}
+      >
+        フィルタをクリア
+      </button>
+    </aside>
+  );
+}
+
+function FilterGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-5 last:mb-0">
+      <h2
+        className="m-0 mb-2 text-[11px] uppercase tracking-[0.08em]"
+        style={{ color: "var(--text-4)", fontWeight: 600 }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function CheckRow({
+  label,
+  count,
+  checked = false,
+}: {
+  label: string;
+  count?: number;
+  checked?: boolean;
+}) {
+  return (
+    <label
+      className="flex cursor-not-allowed items-center justify-between py-1 text-[13px] opacity-70"
+      style={{ color: "var(--text-2)" }}
+    >
+      <span className="inline-flex items-center gap-2">
+        <input
+          type="checkbox"
+          disabled
+          defaultChecked={checked}
+          aria-disabled="true"
+          className="cursor-not-allowed"
+          style={{ accentColor: "var(--accent-solid)" }}
+        />
+        {label}
+      </span>
+      {typeof count === "number" ? (
+        <span className="cm-mono" style={{ color: "var(--text-4)" }}>
+          {count}
+        </span>
+      ) : null}
+    </label>
+  );
+}
+
+function TagChip({ label }: { label: string }) {
+  return (
+    <span
+      className="cursor-not-allowed rounded-[999px] border px-2.5 py-0.5 text-[12px] opacity-70"
+      style={{
+        background: "var(--bg-2)",
+        borderColor: "var(--line-1)",
+        color: "var(--text-2)",
+      }}
+      aria-disabled="true"
+      role="presentation"
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/app/(protected)/_components/BrowseToolbar.tsx
+++ b/src/app/(protected)/_components/BrowseToolbar.tsx
@@ -1,0 +1,49 @@
+import { LayoutGrid, Rows3 } from "lucide-react";
+
+export type SortOption = { key: string; label: string };
+
+type Props = {
+  total: number;
+  sortOptions: ReadonlyArray<SortOption>;
+  activeSortKey: string;
+};
+
+export function BrowseToolbar({ total, sortOptions, activeSortKey }: Props) {
+  return (
+    <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+      <div className="text-[13px]" style={{ color: "var(--text-3)" }}>
+        <b style={{ color: "var(--text-1)" }}>{total}</b> / {total} 件
+      </div>
+      <div className="flex items-center gap-2">
+        <fieldset className="cm-segment m-0 border-0 p-[3px]" disabled>
+          <legend className="sr-only">並び替え (UI プレビュー)</legend>
+          {sortOptions.map((opt) => (
+            <button
+              key={opt.key}
+              type="button"
+              aria-pressed={opt.key === activeSortKey}
+              className="cursor-not-allowed"
+            >
+              {opt.label}
+            </button>
+          ))}
+        </fieldset>
+        <fieldset className="cm-segment m-0 border-0 p-[3px]">
+          <legend className="sr-only">表示切替 (UI プレビュー)</legend>
+          <button type="button" aria-pressed="true" aria-label="グリッド表示">
+            <LayoutGrid className="size-3.5" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            disabled
+            aria-pressed="false"
+            aria-label="リスト表示 (準備中)"
+            className="cursor-not-allowed"
+          >
+            <Rows3 className="size-3.5" aria-hidden="true" />
+          </button>
+        </fieldset>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/_components/CourseCard.tsx
+++ b/src/app/(protected)/_components/CourseCard.tsx
@@ -1,0 +1,112 @@
+import { BookText } from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import type { CourseAuthor, CourseWithLessonsAndAuthor } from "@/repositories";
+
+const COVER_VARIANTS = [
+  "cm-cover-1",
+  "cm-cover-2",
+  "cm-cover-3",
+  "cm-cover-4",
+  "cm-cover-5",
+  "cm-cover-6",
+] as const;
+
+export function coverForIndex(index: number) {
+  return COVER_VARIANTS[index % COVER_VARIANTS.length];
+}
+
+export function glyphForTitle(title: string) {
+  const trimmed = title.trim();
+  if (!trimmed) return "TS";
+  return Array.from(trimmed).slice(0, 2).join("").toUpperCase();
+}
+
+export function authorLabel(author: CourseAuthor | null): string {
+  // Fall back to "Anonymous" when the author didn't set a display name —
+  // do NOT derive a handle from the email address (privacy).
+  return author?.name ?? "Anonymous";
+}
+
+export function authorInitial(author: CourseAuthor | null): string {
+  const label = authorLabel(author);
+  return (Array.from(label.trim())[0] ?? "?").toUpperCase();
+}
+
+type Props = {
+  course: CourseWithLessonsAndAuthor;
+  index: number;
+  completedIds: Set<string>;
+};
+
+export function CourseCard({ course, index, completedIds }: Props) {
+  const total = course.lessons.length;
+  const done = course.lessons.filter((l) => completedIds.has(l.id)).length;
+  const pct = total === 0 ? 0 : Math.round((done / total) * 100);
+
+  return (
+    <Link
+      href={`/courses/${course.slug}`}
+      className={cn(
+        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
+        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
+      )}
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <div className={cn("cm-cover", coverForIndex(index))}>
+        <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
+          <span className="cm-diff-badge cm-diff-1">初級</span>
+        </div>
+        <span className="cm-cover-glyph" aria-hidden="true">
+          {glyphForTitle(course.title)}
+        </span>
+      </div>
+      <div className="flex flex-1 flex-col gap-2.5 p-4">
+        <h3
+          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
+          style={{ color: "var(--text-1)" }}
+        >
+          {course.title}
+        </h3>
+
+        <div className="flex items-center gap-1.5">
+          <span className="cm-avatar cm-avatar-sm" aria-hidden="true">
+            {authorInitial(course.author)}
+          </span>
+          <span className="text-[12px]" style={{ color: "var(--text-3)" }}>
+            {authorLabel(course.author)}
+          </span>
+        </div>
+
+        {course.description ? (
+          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
+            {course.description}
+          </p>
+        ) : null}
+
+        <div className="flex flex-wrap gap-1.5">
+          <span className="cm-chip">#TypeScript</span>
+          <span className="cm-chip">#基礎</span>
+        </div>
+
+        <div className="mt-auto flex items-center gap-3">
+          <div className="cm-progress flex-1">
+            <span style={{ width: `${pct}%` }} />
+          </div>
+          <span className="cm-mono" style={{ color: "var(--text-3)" }}>
+            {done}/{total}
+          </span>
+        </div>
+        <div
+          className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
+          style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
+        >
+          <span className="inline-flex items-center gap-1">
+            <BookText className="size-3" aria-hidden="true" />
+            <b style={{ color: "var(--text-1)" }}>{total}</b> レッスン
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/(protected)/_components/TopBar.tsx
+++ b/src/app/(protected)/_components/TopBar.tsx
@@ -35,7 +35,7 @@ export function TopBar({ displayName, avatarInitial }: Props) {
       }}
     >
       <Link
-        href="/"
+        href="/explore"
         className="flex items-center gap-2.5 font-bold text-[15px] tracking-tight"
         aria-label="codeMaker ホーム"
       >

--- a/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
+++ b/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
@@ -12,10 +12,15 @@ import {
 } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "@/lib/utils";
 import { useLessonRunner } from "../_hooks/useLessonRunner";
+
+const MIN_LEFT_PX = 280;
+const MAX_LEFT_RATIO = 0.75;
+const KEY_NUDGE_PX = 24;
 
 const MonacoEditor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
 
@@ -60,6 +65,76 @@ export default function LessonClient({
       output.exitCode === 0 &&
       lesson.expectedOutput !== null &&
       output.stdout.trim() === lesson.expectedOutput.trim());
+
+  const splitRef = useRef<HTMLDivElement>(null);
+  const [leftWidth, setLeftWidth] = useState<number | null>(null);
+  const draggingRef = useRef(false);
+
+  const clampLeftWidth = useCallback((raw: number, containerWidth: number) => {
+    const max = Math.max(MIN_LEFT_PX, containerWidth * MAX_LEFT_RATIO);
+    return Math.max(MIN_LEFT_PX, Math.min(raw, max));
+  }, []);
+
+  const onResizerMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    draggingRef.current = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const onResizerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!splitRef.current) return;
+      const rect = splitRef.current.getBoundingClientRect();
+      const current = leftWidth ?? rect.width / 2;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        setLeftWidth(clampLeftWidth(current - KEY_NUDGE_PX, rect.width));
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        setLeftWidth(clampLeftWidth(current + KEY_NUDGE_PX, rect.width));
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        setLeftWidth(MIN_LEFT_PX);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        setLeftWidth(clampLeftWidth(rect.width * MAX_LEFT_RATIO, rect.width));
+      }
+    },
+    [leftWidth, clampLeftWidth],
+  );
+
+  useEffect(() => {
+    // Syncing drag state with window-level mouse events so dragging still works
+    // when the pointer leaves the resizer handle.
+    const onMove = (event: MouseEvent) => {
+      if (!draggingRef.current || !splitRef.current) return;
+      const rect = splitRef.current.getBoundingClientRect();
+      const raw = event.clientX - rect.left;
+      setLeftWidth(clampLeftWidth(raw, rect.width));
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [clampLeftWidth]);
+
+  const splitStyle: CSSProperties =
+    leftWidth !== null
+      ? { gridTemplateColumns: `${leftWidth}px 6px minmax(0,1fr)`, flex: 1 }
+      : {
+          gridTemplateColumns: "minmax(280px, 1fr) 6px minmax(420px, 1.2fr)",
+          flex: 1,
+        };
 
   return (
     <div
@@ -108,16 +183,10 @@ export default function LessonClient({
       </header>
 
       {/* Split pane */}
-      <div
-        className="grid overflow-hidden"
-        style={{
-          gridTemplateColumns: "minmax(280px, 1fr) minmax(420px, 1.2fr)",
-          flex: 1,
-        }}
-      >
+      <div ref={splitRef} className="grid overflow-hidden" style={splitStyle}>
         {/* LEFT: problem statement */}
         <div
-          className="flex flex-col overflow-hidden border-r"
+          className="flex flex-col overflow-hidden"
           style={{ borderColor: "var(--line-1)", minWidth: 0 }}
         >
           <div
@@ -262,6 +331,30 @@ export default function LessonClient({
               ) : null}
             </div>
           </div>
+        </div>
+
+        {/* Resizer */}
+        {/* biome-ignore lint/a11y/useSemanticElements: ARIA separator role is required for split-pane resize handles; <hr> cannot host interactive behavior */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="問題とエディターの横幅を調整"
+          aria-valuemin={MIN_LEFT_PX}
+          aria-valuenow={leftWidth ?? undefined}
+          tabIndex={0}
+          onMouseDown={onResizerMouseDown}
+          onKeyDown={onResizerKeyDown}
+          className="relative flex cursor-col-resize touch-none items-center justify-center border-r border-l transition-colors hover:bg-[var(--bg-2)] focus-visible:bg-[var(--bg-2)]"
+          style={{
+            borderColor: "var(--line-1)",
+            background: "var(--bg-0)",
+          }}
+        >
+          <span
+            aria-hidden="true"
+            className="h-8 w-0.5 rounded"
+            style={{ background: "var(--line-2)" }}
+          />
         </div>
 
         {/* RIGHT: editor + results */}

--- a/src/app/(protected)/dashboard/_components/DeleteCourseButton.tsx
+++ b/src/app/(protected)/dashboard/_components/DeleteCourseButton.tsx
@@ -1,8 +1,19 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { deleteCourseAction } from "@/actions/dashboard/course";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 
 type Props = {
@@ -11,27 +22,49 @@ type Props = {
 };
 
 export function DeleteCourseButton({ courseId, title }: Props) {
+  const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const onClick = () => {
-    if (!window.confirm(`コース「${title}」を削除しますか？\nレッスンも一緒に削除されます。`)) {
-      return;
-    }
+  const onConfirm = () => {
     startTransition(async () => {
       await deleteCourseAction({ id: courseId });
+      setOpen(false);
     });
   };
 
   return (
-    <Button
-      aria-label={`コース「${title}」を削除`}
-      disabled={isPending}
-      onClick={onClick}
-      size="icon-sm"
-      type="button"
-      variant="destructive"
-    >
-      <Trash2 aria-hidden="true" />
-    </Button>
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger
+        render={
+          <Button
+            aria-label={`コース「${title}」を削除`}
+            size="icon-sm"
+            type="button"
+            variant="destructive"
+          />
+        }
+      >
+        <Trash2 aria-hidden="true" />
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>コースを削除しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            コース「{title}」と紐づくレッスンがすべて削除されます。この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            disabled={isPending}
+            onClick={onConfirm}
+            type="button"
+          >
+            {isPending ? "削除中…" : "削除する"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/src/app/(protected)/dashboard/_components/DeleteLessonButton.tsx
+++ b/src/app/(protected)/dashboard/_components/DeleteLessonButton.tsx
@@ -1,8 +1,19 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { deleteLessonAction } from "@/actions/dashboard/lesson";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 
 type Props = {
@@ -11,27 +22,49 @@ type Props = {
 };
 
 export function DeleteLessonButton({ lessonId, title }: Props) {
+  const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const onClick = () => {
-    if (!window.confirm(`レッスン「${title}」を削除しますか？`)) {
-      return;
-    }
+  const onConfirm = () => {
     startTransition(async () => {
       await deleteLessonAction({ id: lessonId });
+      setOpen(false);
     });
   };
 
   return (
-    <Button
-      aria-label={`レッスン「${title}」を削除`}
-      disabled={isPending}
-      onClick={onClick}
-      size="icon-sm"
-      type="button"
-      variant="destructive"
-    >
-      <Trash2 aria-hidden="true" />
-    </Button>
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger
+        render={
+          <Button
+            aria-label={`レッスン「${title}」を削除`}
+            size="icon-sm"
+            type="button"
+            variant="destructive"
+          />
+        }
+      >
+        <Trash2 aria-hidden="true" />
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>レッスンを削除しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            レッスン「{title}」が削除されます。この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            disabled={isPending}
+            onClick={onConfirm}
+            type="button"
+          >
+            {isPending ? "削除中…" : "削除する"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/src/app/(protected)/explore/page.tsx
+++ b/src/app/(protected)/explore/page.tsx
@@ -1,63 +1,18 @@
-import { BookText, LayoutGrid, Rows3 } from "lucide-react";
-import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
-import { cn } from "@/lib/utils";
-import type { CourseAuthor } from "@/repositories";
 import { getPublishedCoursesByNewest } from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
+import { BrowseFilterPanel } from "../_components/BrowseFilterPanel";
+import { BrowseToolbar, type SortOption } from "../_components/BrowseToolbar";
+import { CourseCard } from "../_components/CourseCard";
 
 export const dynamic = "force-dynamic";
 
-const COVER_VARIANTS = [
-  "cm-cover-1",
-  "cm-cover-2",
-  "cm-cover-3",
-  "cm-cover-4",
-  "cm-cover-5",
-  "cm-cover-6",
-] as const;
-
-const DIFFICULTY_FILTERS = [
-  { key: "beginner", label: "初級" },
-  { key: "intermediate", label: "中級" },
-  { key: "advanced", label: "上級" },
-] as const;
-
-const TAG_FILTERS = ["TypeScript", "基礎", "型", "関数", "配列", "オブジェクト", "入門"] as const;
-
-const LANGUAGE_FILTERS = [
-  { key: "typescript", label: "TypeScript", active: true },
-  { key: "javascript", label: "JavaScript", active: false },
-  { key: "python", label: "Python", active: false },
-] as const;
-
-const SORT_OPTIONS = [
+const EXPLORE_SORT_OPTIONS: ReadonlyArray<SortOption> = [
   { key: "newest", label: "新着" },
   { key: "popular", label: "人気" },
   { key: "ac-rate", label: "AC率高" },
   { key: "unchallenged", label: "未挑戦" },
-] as const;
-
-function coverFor(index: number) {
-  return COVER_VARIANTS[index % COVER_VARIANTS.length];
-}
-
-function glyphFor(title: string) {
-  const trimmed = title.trim();
-  if (!trimmed) return "TS";
-  return Array.from(trimmed).slice(0, 2).join("").toUpperCase();
-}
-
-function authorLabel(author: CourseAuthor | null): string {
-  // Fall back to "Anonymous" when the author didn't set a display name —
-  // do NOT derive a handle from the email address (privacy).
-  return author?.name ?? "Anonymous";
-}
-
-function authorInitial(author: CourseAuthor | null): string {
-  const label = authorLabel(author);
-  return (Array.from(label.trim())[0] ?? "?").toUpperCase();
-}
+];
 
 export default async function ExplorePage() {
   const session = await requireAuth();
@@ -77,284 +32,38 @@ export default async function ExplorePage() {
       </header>
 
       <div className="grid grid-cols-1 gap-7 md:grid-cols-[240px_minmax(0,1fr)]">
-        <FilterPanel />
-        <ExploreMain courses={courses} completedIds={completedIds} />
-      </div>
-    </div>
-  );
-}
-
-function FilterPanel() {
-  return (
-    <aside
-      className="h-max rounded-[14px] p-4 md:sticky md:top-20"
-      style={{
-        background: "var(--bg-1)",
-        border: "1px solid var(--line-1)",
-      }}
-      aria-label="フィルタ (UI プレビュー)"
-    >
-      <FilterGroup title="難易度">
-        <ul className="space-y-0.5">
-          {DIFFICULTY_FILTERS.map((d) => (
-            <li key={d.key}>
-              <CheckRow label={d.label} count={0} />
-            </li>
-          ))}
-        </ul>
-      </FilterGroup>
-
-      <FilterGroup title="タグ">
-        <div className="flex flex-wrap gap-1.5">
-          {TAG_FILTERS.map((tag) => (
-            <TagChip key={tag} label={tag} />
-          ))}
-        </div>
-      </FilterGroup>
-
-      <FilterGroup title="対応言語">
-        <ul className="space-y-0.5">
-          {LANGUAGE_FILTERS.map((l) => (
-            <li key={l.key}>
-              <CheckRow label={l.label} checked={l.active} />
-            </li>
-          ))}
-        </ul>
-      </FilterGroup>
-
-      <button
-        type="button"
-        disabled
-        aria-disabled="true"
-        className="mt-2 inline-flex w-full cursor-not-allowed items-center justify-center rounded-[6px] px-2.5 py-1.5 text-[12px] opacity-60"
-        style={{ color: "var(--text-2)" }}
-      >
-        フィルタをクリア
-      </button>
-    </aside>
-  );
-}
-
-function FilterGroup({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <section className="mb-5 last:mb-0">
-      <h2
-        className="m-0 mb-2 text-[11px] uppercase tracking-[0.08em]"
-        style={{ color: "var(--text-4)", fontWeight: 600 }}
-      >
-        {title}
-      </h2>
-      {children}
-    </section>
-  );
-}
-
-function CheckRow({
-  label,
-  count,
-  checked = false,
-}: {
-  label: string;
-  count?: number;
-  checked?: boolean;
-}) {
-  return (
-    <label
-      className="flex cursor-not-allowed items-center justify-between py-1 text-[13px] opacity-70"
-      style={{ color: "var(--text-2)" }}
-    >
-      <span className="inline-flex items-center gap-2">
-        <input
-          type="checkbox"
-          disabled
-          defaultChecked={checked}
-          aria-disabled="true"
-          className="cursor-not-allowed"
-          style={{ accentColor: "var(--accent-solid)" }}
-        />
-        {label}
-      </span>
-      {typeof count === "number" ? (
-        <span className="cm-mono" style={{ color: "var(--text-4)" }}>
-          {count}
-        </span>
-      ) : null}
-    </label>
-  );
-}
-
-function TagChip({ label }: { label: string }) {
-  return (
-    <span
-      className="cursor-not-allowed rounded-[999px] border px-2.5 py-0.5 text-[12px] opacity-70"
-      style={{
-        background: "var(--bg-2)",
-        borderColor: "var(--line-1)",
-        color: "var(--text-2)",
-      }}
-      aria-disabled="true"
-      role="presentation"
-    >
-      {label}
-    </span>
-  );
-}
-
-type ExploreCourse = Awaited<ReturnType<typeof getPublishedCoursesByNewest>>[number];
-
-function ExploreMain({
-  courses,
-  completedIds,
-}: {
-  courses: ExploreCourse[];
-  completedIds: Set<string>;
-}) {
-  return (
-    <main className="min-w-0">
-      <Toolbar total={courses.length} />
-      {courses.length === 0 ? (
-        <div
-          className="rounded-[14px] px-8 py-14 text-center text-[13px]"
-          style={{
-            background: "var(--bg-1)",
-            border: "1px dashed var(--line-3)",
-            color: "var(--text-3)",
-          }}
-        >
-          公開されているコースがまだありません。
-        </div>
-      ) : (
-        <ul
-          className="grid gap-4"
-          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
-        >
-          {courses.map((c, idx) => (
-            <li key={c.id}>
-              <ExploreCard course={c} index={idx} completedIds={completedIds} />
-            </li>
-          ))}
-        </ul>
-      )}
-    </main>
-  );
-}
-
-function Toolbar({ total }: { total: number }) {
-  return (
-    <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
-      <div className="text-[13px]" style={{ color: "var(--text-3)" }}>
-        <b style={{ color: "var(--text-1)" }}>{total}</b> / {total} 件
-      </div>
-      <div className="flex items-center gap-2">
-        <fieldset className="cm-segment m-0 border-0 p-[3px]" disabled>
-          <legend className="sr-only">並び替え (UI プレビュー)</legend>
-          {SORT_OPTIONS.map((opt) => (
-            <button
-              key={opt.key}
-              type="button"
-              aria-pressed={opt.key === "newest"}
-              className="cursor-not-allowed"
+        <BrowseFilterPanel ariaLabel="フィルタ (探す / UI プレビュー)" />
+        <main className="min-w-0">
+          <BrowseToolbar
+            total={courses.length}
+            sortOptions={EXPLORE_SORT_OPTIONS}
+            activeSortKey="newest"
+          />
+          {courses.length === 0 ? (
+            <div
+              className="rounded-[14px] px-8 py-14 text-center text-[13px]"
+              style={{
+                background: "var(--bg-1)",
+                border: "1px dashed var(--line-3)",
+                color: "var(--text-3)",
+              }}
             >
-              {opt.label}
-            </button>
-          ))}
-        </fieldset>
-        <fieldset className="cm-segment m-0 border-0 p-[3px]">
-          <legend className="sr-only">表示切替 (UI プレビュー)</legend>
-          <button type="button" aria-pressed="true" aria-label="グリッド表示">
-            <LayoutGrid className="size-3.5" aria-hidden="true" />
-          </button>
-          <button
-            type="button"
-            disabled
-            aria-pressed="false"
-            aria-label="リスト表示 (準備中)"
-            className="cursor-not-allowed"
-          >
-            <Rows3 className="size-3.5" aria-hidden="true" />
-          </button>
-        </fieldset>
+              公開されているコースがまだありません。
+            </div>
+          ) : (
+            <ul
+              className="grid gap-4"
+              style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
+            >
+              {courses.map((course, idx) => (
+                <li key={course.id}>
+                  <CourseCard course={course} index={idx} completedIds={completedIds} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </main>
       </div>
     </div>
-  );
-}
-
-function ExploreCard({
-  course,
-  index,
-  completedIds,
-}: {
-  course: ExploreCourse;
-  index: number;
-  completedIds: Set<string>;
-}) {
-  const total = course.lessons.length;
-  const done = course.lessons.filter((l) => completedIds.has(l.id)).length;
-  const pct = total === 0 ? 0 : Math.round((done / total) * 100);
-
-  return (
-    <Link
-      href={`/courses/${course.slug}`}
-      className={cn(
-        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
-        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
-      )}
-      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-    >
-      <div className={cn("cm-cover", coverFor(index))}>
-        <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
-          <span className="cm-diff-badge cm-diff-1">初級</span>
-        </div>
-        <span className="cm-cover-glyph" aria-hidden="true">
-          {glyphFor(course.title)}
-        </span>
-      </div>
-      <div className="flex flex-1 flex-col gap-2.5 p-4">
-        <h3
-          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
-          style={{ color: "var(--text-1)" }}
-        >
-          {course.title}
-        </h3>
-
-        <div className="flex items-center gap-1.5">
-          <span className="cm-avatar cm-avatar-sm" aria-hidden="true">
-            {authorInitial(course.author)}
-          </span>
-          <span className="text-[12px]" style={{ color: "var(--text-3)" }}>
-            {authorLabel(course.author)}
-          </span>
-        </div>
-
-        {course.description ? (
-          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
-            {course.description}
-          </p>
-        ) : null}
-
-        <div className="flex flex-wrap gap-1.5">
-          <span className="cm-chip">#TypeScript</span>
-          <span className="cm-chip">#基礎</span>
-        </div>
-
-        <div className="mt-auto flex items-center gap-3">
-          <div className="cm-progress flex-1">
-            <span style={{ width: `${pct}%` }} />
-          </div>
-          <span className="cm-mono" style={{ color: "var(--text-3)" }}>
-            {done}/{total}
-          </span>
-        </div>
-        <div
-          className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
-          style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
-        >
-          <span className="inline-flex items-center gap-1">
-            <BookText className="size-3" aria-hidden="true" />
-            <b style={{ color: "var(--text-1)" }}>{total}</b> レッスン
-          </span>
-        </div>
-      </div>
-    </Link>
   );
 }

--- a/src/app/(protected)/me/page.tsx
+++ b/src/app/(protected)/me/page.tsx
@@ -109,38 +109,7 @@ export default async function MePage() {
             過去52週間の活動 (準備中)
           </span>
         </div>
-        <div
-          className="overflow-x-auto rounded-[14px]"
-          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-        >
-          <div
-            className="grid gap-[3px] p-4"
-            style={{
-              gridAutoFlow: "column",
-              gridTemplateRows: "repeat(7, 10px)",
-              width: "max-content",
-            }}
-          >
-            {Array.from({ length: 7 * 52 }, (_, i) => `cell-${i}`).map((id) => (
-              <div key={id} className="cm-heat-cell" />
-            ))}
-          </div>
-          <div
-            className="flex items-center justify-between border-t px-4 py-2.5 text-[12px]"
-            style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
-          >
-            <span>活動データは近日公開</span>
-            <div className="flex items-center gap-1 text-[11px]" style={{ color: "var(--text-4)" }}>
-              少ない
-              <span className="cm-heat-cell" />
-              <span className="cm-heat-cell cm-heat-1" />
-              <span className="cm-heat-cell cm-heat-2" />
-              <span className="cm-heat-cell cm-heat-3" />
-              <span className="cm-heat-cell cm-heat-4" />
-              多い
-            </div>
-          </div>
-        </div>
+        <Heatmap />
       </section>
 
       {/* My courses */}
@@ -230,6 +199,142 @@ export default async function MePage() {
           </ul>
         )}
       </section>
+    </div>
+  );
+}
+
+const HEATMAP_WEEKS = 52;
+const HEATMAP_DAYS = 7;
+const HEATMAP_CELL_SIZE = 13;
+const HEATMAP_CELL_GAP = 4;
+const MONTH_LABELS_JA = [
+  "1月",
+  "2月",
+  "3月",
+  "4月",
+  "5月",
+  "6月",
+  "7月",
+  "8月",
+  "9月",
+  "10月",
+  "11月",
+  "12月",
+];
+
+function buildMonthLabels(weekCount = HEATMAP_WEEKS) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const dayOfWeek = today.getDay();
+  // Treat Monday as start of week. getDay(): Sun=0..Sat=6 → offset to Monday.
+  const offsetToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const lastMonday = new Date(today);
+  lastMonday.setDate(today.getDate() + offsetToMonday);
+  const firstMonday = new Date(lastMonday);
+  firstMonday.setDate(lastMonday.getDate() - (weekCount - 1) * 7);
+
+  const labels: { colIndex: number; month: number }[] = [];
+  let prevMonth = -1;
+  for (let w = 0; w < weekCount; w++) {
+    const firstDay = new Date(firstMonday);
+    firstDay.setDate(firstMonday.getDate() + w * 7);
+    const month = firstDay.getMonth();
+    if (month !== prevMonth) {
+      // Keep labels at least 2 columns apart to avoid visual crowding.
+      if (w === 0 || w - (labels.at(-1)?.colIndex ?? -2) >= 2) {
+        labels.push({ colIndex: w, month });
+      }
+      prevMonth = month;
+    }
+  }
+  return labels;
+}
+
+function Heatmap() {
+  const monthLabels = buildMonthLabels();
+  const totalCells = HEATMAP_WEEKS * HEATMAP_DAYS;
+  const cellStride = HEATMAP_CELL_SIZE + HEATMAP_CELL_GAP;
+  const gridWidth = HEATMAP_WEEKS * HEATMAP_CELL_SIZE + (HEATMAP_WEEKS - 1) * HEATMAP_CELL_GAP;
+  // Rows (Mon-Sun). Show labels only on Mon/Wed/Fri (rows 0/2/4) to avoid crowding.
+  const weekdayLabels = ["月", "", "水", "", "金", "", ""];
+
+  return (
+    <div
+      className="overflow-x-auto rounded-[14px]"
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <div className="p-4" style={{ width: "max-content" }}>
+        {/* Month label row */}
+        <div className="flex" style={{ marginLeft: 24 }}>
+          <div
+            className="relative text-[11px]"
+            style={{ width: gridWidth, height: 16, color: "var(--text-4)" }}
+          >
+            {monthLabels.map((ml) => (
+              <span
+                key={`${ml.colIndex}-${ml.month}`}
+                className="absolute top-0 font-mono"
+                style={{ left: ml.colIndex * cellStride }}
+              >
+                {MONTH_LABELS_JA[ml.month]}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Weekday labels + cells */}
+        <div className="flex items-start">
+          <div
+            className="grid font-mono text-[11px]"
+            style={{
+              width: 24,
+              gridTemplateRows: `repeat(${HEATMAP_DAYS}, ${HEATMAP_CELL_SIZE}px)`,
+              rowGap: HEATMAP_CELL_GAP,
+              color: "var(--text-4)",
+            }}
+          >
+            {weekdayLabels.map((label, idx) => (
+              <span
+                key={`wd-${
+                  // biome-ignore lint/suspicious/noArrayIndexKey: weekday labels are static positional
+                  idx
+                }`}
+                className="flex items-center leading-none"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+          <div
+            className="grid"
+            style={{
+              gridAutoFlow: "column",
+              gridTemplateRows: `repeat(${HEATMAP_DAYS}, ${HEATMAP_CELL_SIZE}px)`,
+              gridAutoColumns: `${HEATMAP_CELL_SIZE}px`,
+              gap: HEATMAP_CELL_GAP,
+            }}
+          >
+            {Array.from({ length: totalCells }, (_, i) => `cell-${i}`).map((id) => (
+              <div key={id} className="cm-heat-cell" />
+            ))}
+          </div>
+        </div>
+      </div>
+      <div
+        className="flex items-center justify-between border-t px-4 py-2.5 text-[12px]"
+        style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
+      >
+        <span>活動データは近日公開</span>
+        <div className="flex items-center gap-1 text-[11px]" style={{ color: "var(--text-4)" }}>
+          少ない
+          <span className="cm-heat-cell" />
+          <span className="cm-heat-cell cm-heat-1" />
+          <span className="cm-heat-cell cm-heat-2" />
+          <span className="cm-heat-cell cm-heat-3" />
+          <span className="cm-heat-cell cm-heat-4" />
+          多い
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -1,31 +1,18 @@
-import { BookText } from "lucide-react";
-import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
-import { cn } from "@/lib/utils";
 import { getCoursesWithLessons } from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
+import { BrowseFilterPanel } from "./_components/BrowseFilterPanel";
+import { BrowseToolbar, type SortOption } from "./_components/BrowseToolbar";
+import { CourseCard } from "./_components/CourseCard";
 
 export const dynamic = "force-dynamic";
 
-const COVER_VARIANTS = [
-  "cm-cover-1",
-  "cm-cover-2",
-  "cm-cover-3",
-  "cm-cover-4",
-  "cm-cover-5",
-  "cm-cover-6",
-] as const;
-
-function coverFor(index: number) {
-  return COVER_VARIANTS[index % COVER_VARIANTS.length];
-}
-
-function glyphFor(title: string) {
-  const trimmed = title.trim();
-  if (!trimmed) return "TS";
-  const chars = Array.from(trimmed);
-  return chars.slice(0, 2).join("").toUpperCase();
-}
+const LEARN_SORT_OPTIONS: ReadonlyArray<SortOption> = [
+  { key: "recommended", label: "おすすめ" },
+  { key: "newest", label: "新着" },
+  { key: "popular", label: "人気" },
+  { key: "ac-rate", label: "AC率高" },
+];
 
 export default async function Home() {
   const session = await requireAuth();
@@ -38,86 +25,37 @@ export default async function Home() {
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
-      <section>
-        <div className="mb-4">
-          <h1 className="m-0 font-semibold text-[22px] tracking-tight">コース一覧</h1>
-          <span className="text-xs" style={{ color: "var(--text-3)" }}>
-            公開されている TypeScript コース
-          </span>
-        </div>
+      <header className="mb-7">
+        <h1 className="m-0 font-bold text-[26px] tracking-tight">学ぶ — キュレーションコース</h1>
+        <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
+          公式が厳選した TypeScript の学習コース
+        </p>
+      </header>
 
-        {courses.length === 0 ? (
-          <EmptyCourses />
-        ) : (
-          <ul
-            className="grid gap-4"
-            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
-          >
-            {courses.map((c, idx) => {
-              const total = c.lessons.length;
-              const done = c.lessons.filter((l) => completedIds.has(l.id)).length;
-              const pct = total === 0 ? 0 : Math.round((done / total) * 100);
-              return (
-                <li key={c.id}>
-                  <Link
-                    href={`/courses/${c.slug}`}
-                    className={cn(
-                      "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
-                      "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
-                    )}
-                    style={{
-                      background: "var(--bg-1)",
-                      border: "1px solid var(--line-1)",
-                    }}
-                  >
-                    <div className={cn("cm-cover", coverFor(idx))}>
-                      <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
-                        <span className="cm-diff-badge cm-diff-1">初級</span>
-                      </div>
-                      <span className="cm-cover-glyph" aria-hidden="true">
-                        {glyphFor(c.title)}
-                      </span>
-                    </div>
-                    <div className="flex flex-1 flex-col gap-2.5 p-4">
-                      <h3
-                        className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
-                        style={{ color: "var(--text-1)" }}
-                      >
-                        {c.title}
-                      </h3>
-                      {c.description ? (
-                        <p
-                          className="m-0 line-clamp-2 text-[12.5px]"
-                          style={{ color: "var(--text-3)" }}
-                        >
-                          {c.description}
-                        </p>
-                      ) : null}
-                      <div className="mt-auto flex items-center gap-3">
-                        <div className="cm-progress flex-1">
-                          <span style={{ width: `${pct}%` }} />
-                        </div>
-                        <span className="cm-mono" style={{ color: "var(--text-3)" }}>
-                          {done}/{total}
-                        </span>
-                      </div>
-                      <div
-                        className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
-                        style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
-                      >
-                        <span className="inline-flex items-center gap-1">
-                          <BookText className="size-3" aria-hidden="true" />
-                          <b style={{ color: "var(--text-1)" }}>{total}</b> レッスン
-                        </span>
-                      </div>
-                    </div>
-                  </Link>
+      <div className="grid grid-cols-1 gap-7 md:grid-cols-[240px_minmax(0,1fr)]">
+        <BrowseFilterPanel ariaLabel="フィルタ (学ぶ / UI プレビュー)" />
+        <main className="min-w-0">
+          <BrowseToolbar
+            total={courses.length}
+            sortOptions={LEARN_SORT_OPTIONS}
+            activeSortKey="recommended"
+          />
+          {courses.length === 0 ? (
+            <EmptyCourses />
+          ) : (
+            <ul
+              className="grid gap-4"
+              style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
+            >
+              {courses.map((course, idx) => (
+                <li key={course.id}>
+                  <CourseCard course={course} index={idx} completedIds={completedIds} />
                 </li>
-              );
-            })}
-          </ul>
-        )}
-      </section>
+              ))}
+            </ul>
+          )}
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -371,9 +371,9 @@
   }
 
   .cm-heat-cell {
-    width: 10px;
-    height: 10px;
-    border-radius: 2px;
+    width: 13px;
+    height: 13px;
+    border-radius: 3px;
     background: var(--bg-2);
   }
   .cm-heat-1 {

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm";
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof Button>) {
+  return <Button data-slot="alert-dialog-action" className={cn(className)} {...props} />;
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -46,7 +46,7 @@ export class CourseRepository extends BaseRepository {
     });
   }
 
-  async findAllPublishedWithLessons(): Promise<CourseWithLessonIds[]> {
+  async findAllPublishedWithLessons(): Promise<CourseWithLessonsAndAuthor[]> {
     return this.client.course.findMany({
       where: { isPublished: true },
       orderBy: { order: "asc" },
@@ -55,6 +55,9 @@ export class CourseRepository extends BaseRepository {
           where: { isPublished: true },
           select: { id: true },
           orderBy: { order: "asc" },
+        },
+        author: {
+          select: { id: true, email: true, name: true, avatarUrl: true },
         },
       },
     });

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -14,7 +14,7 @@ import { ensureAuthorOwnsCourse } from "./authorGuard";
 
 export async function getCoursesWithLessons(
   repository: CourseRepository = courseRepository,
-): Promise<CourseWithLessonIds[]> {
+): Promise<CourseWithLessonsAndAuthor[]> {
   logInfo("courseService.getCoursesWithLessons.start");
   try {
     const result = await repository.findAllPublishedWithLessons();


### PR DESCRIPTION
## Summary

Issue #53 の残り UI 作業をまとめて対応:

- **/me ヒートマップ**: cell を 10px → 13px に拡大、gap を 4px に、月ラベル (1月/2月…) を上部に、曜日ラベル (月/水/金) を左端に追加。
- **Home (/) を explore 風レイアウトに**: 共有の `BrowseFilterPanel` / `BrowseToolbar` / `CourseCard` に切り出し、Home / Explore の両方でサイドバーとツールバーが揃うように。`getCoursesWithLessons` の返り値に author を含めて Home のカードにも作者情報を表示。Home の sort は `おすすめ` 既定 (disabled)。
- **レッスン画面のリサイザー**: 問題ペインとエディターペインの間をマウスドラッグで左右比可変に。キーボード (←/→/Home/End) も対応、`role="separator"`。最小 280px、最大 75%。
- **TopBar のブランドリンクを `/explore` に**: 最小変更で Home は残したまま、ブランド押下は community 側に誘導。
- **コース/レッスン削除モーダル化**: `window.confirm` を shadcn `alert-dialog` に置換。`shadcn@latest add alert-dialog` で primitive を追加。

## Test plan

- [ ] `npm run build` が通る (ローカル確認済)
- [ ] `./node_modules/.bin/tsc --noEmit` が通る (ローカル確認済)
- [ ] `npm run check` が通る (ローカル確認済)
- [ ] `npm run dev` で以下を目視確認:
  - [ ] `/` で filter panel + toolbar が出る / author 情報が出る
  - [ ] `/me` のヒートマップに月ラベル・曜日ラベルが出て cell が視認しやすい
  - [ ] レッスン画面で resizer をドラッグして比率が変わる (最小 280px / 最大 75%)
  - [ ] TopBar ブランドリンクで `/explore` に遷移
  - [ ] dashboard でコース/レッスン削除時に alert-dialog が出る

Closes #53