### PR TITLE
feat(search): Course/Lesson search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "typescript": "^5"
       },
       "engines": {
-        "node": ">=20.12.0"
+        "node": "24.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/app/(protected)/_components/TopBar.tsx
+++ b/src/app/(protected)/_components/TopBar.tsx
@@ -59,11 +59,13 @@ export function TopBar({ displayName, avatarInitial }: Props) {
           className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-3.5"
           style={{ color: "var(--text-3)" }}
         />
+        {/* `key` forces a remount whenever the URL query changes so `defaultValue`
+            re-syncs (e.g. navigating back/forward between search pages). */}
         <input
+          key={initialQuery}
           type="search"
           name="q"
           defaultValue={initialQuery}
-          key={initialQuery}
           placeholder="コース・レッスンを検索"
           aria-label="コース・レッスンを検索"
           autoComplete="off"
@@ -74,9 +76,6 @@ export function TopBar({ displayName, avatarInitial }: Props) {
             color: "var(--text-1)",
           }}
         />
-        <button type="submit" className="sr-only">
-          検索する
-        </button>
       </form>
 
       <div className="flex items-center gap-2">

--- a/src/app/(protected)/_components/TopBar.tsx
+++ b/src/app/(protected)/_components/TopBar.tsx
@@ -2,7 +2,7 @@
 
 import { Bell, BookOpen, Compass, Plus, Search } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 type Props = {
@@ -23,7 +23,9 @@ function resolveNavGroup(pathname: string): NavGroup {
 
 export function TopBar({ displayName, avatarInitial }: Props) {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const group = resolveNavGroup(pathname);
+  const initialQuery = pathname === "/search" ? (searchParams.get("q") ?? "") : "";
 
   return (
     <header
@@ -51,7 +53,7 @@ export function TopBar({ displayName, avatarInitial }: Props) {
         </span>
       </Link>
 
-      <div className="relative mx-auto w-full max-w-[520px]">
+      <form action="/search" method="get" className="relative mx-auto w-full max-w-[520px]">
         <Search
           aria-hidden="true"
           className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-3.5"
@@ -59,21 +61,23 @@ export function TopBar({ displayName, avatarInitial }: Props) {
         />
         <input
           type="search"
-          disabled
-          placeholder="検索 (近日公開)"
-          aria-label="検索 (近日公開)"
-          className="w-full cursor-not-allowed rounded-[10px] py-[9px] pr-16 pl-10 text-[13px] outline-none transition"
+          name="q"
+          defaultValue={initialQuery}
+          key={initialQuery}
+          placeholder="コース・レッスンを検索"
+          aria-label="コース・レッスンを検索"
+          autoComplete="off"
+          className="w-full rounded-[10px] py-[9px] pr-10 pl-10 text-[13px] outline-none transition focus:border-[color:var(--accent-solid)]"
           style={{
             background: "var(--bg-1)",
             border: "1px solid var(--line-2)",
             color: "var(--text-1)",
           }}
         />
-        <span className="-translate-y-1/2 absolute top-1/2 right-2.5 flex gap-1">
-          <span className="cm-kbd">⌘</span>
-          <span className="cm-kbd">K</span>
-        </span>
-      </div>
+        <button type="submit" className="sr-only">
+          検索する
+        </button>
+      </form>
 
       <div className="flex items-center gap-2">
         <nav

--- a/src/app/(protected)/search/page.tsx
+++ b/src/app/(protected)/search/page.tsx
@@ -1,0 +1,220 @@
+import { BookText, FileText, Search as SearchIcon } from "lucide-react";
+import Link from "next/link";
+import { requireAuth } from "@/lib/auth";
+import type { CourseSearchHit, LessonSearchHit } from "@/repositories";
+import { search } from "@/services/searchService";
+
+export const dynamic = "force-dynamic";
+
+function firstParam(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? "";
+  return value ?? "";
+}
+
+export default async function SearchPage({ searchParams }: PageProps<"/search">) {
+  await requireAuth();
+  const sp = await searchParams;
+  const rawQuery = firstParam(sp?.q);
+  const { query, courses, lessons } = await search(rawQuery);
+  const hasQuery = query.length > 0;
+  const totalHits = courses.length + lessons.length;
+
+  return (
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
+      <Header query={query} hasQuery={hasQuery} totalHits={totalHits} />
+
+      {!hasQuery ? (
+        <EmptyState
+          title="検索キーワードを入力してください"
+          description="上部の検索バーにコース名やレッスン名、本文のキーワードを入力して Enter。"
+        />
+      ) : totalHits === 0 ? (
+        <EmptyState
+          title={`「${query}」に一致する結果はありません`}
+          description="別のキーワードで検索してみてください。"
+        />
+      ) : (
+        <div className="flex flex-col gap-10">
+          <CourseSection courses={courses} />
+          <LessonSection lessons={lessons} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Header({
+  query,
+  hasQuery,
+  totalHits,
+}: {
+  query: string;
+  hasQuery: boolean;
+  totalHits: number;
+}) {
+  return (
+    <header className="mb-7">
+      <h1 className="m-0 font-bold text-[26px] tracking-tight">検索結果</h1>
+      {hasQuery ? (
+        <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
+          <span className="cm-mono" style={{ color: "var(--text-1)" }}>
+            {query}
+          </span>{" "}
+          の結果 <b style={{ color: "var(--text-1)" }}>{totalHits}</b> 件
+        </p>
+      ) : null}
+    </header>
+  );
+}
+
+function CourseSection({ courses }: { courses: CourseSearchHit[] }) {
+  if (courses.length === 0) return null;
+  return (
+    <section aria-labelledby="search-courses-heading">
+      <SectionHeading id="search-courses-heading" label="コース" count={courses.length} />
+      <ul className="mt-3 flex flex-col gap-2">
+        {courses.map((course) => (
+          <li key={course.id}>
+            <CourseResultRow course={course} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function LessonSection({ lessons }: { lessons: LessonSearchHit[] }) {
+  if (lessons.length === 0) return null;
+  return (
+    <section aria-labelledby="search-lessons-heading">
+      <SectionHeading id="search-lessons-heading" label="レッスン" count={lessons.length} />
+      <ul className="mt-3 flex flex-col gap-2">
+        {lessons.map((lesson) => (
+          <li key={lesson.id}>
+            <LessonResultRow lesson={lesson} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function SectionHeading({ id, label, count }: { id: string; label: string; count: number }) {
+  return (
+    <h2
+      id={id}
+      className="m-0 flex items-baseline gap-2 font-semibold text-[15px] tracking-tight"
+      style={{ color: "var(--text-1)" }}
+    >
+      {label}
+      <span className="cm-mono font-normal text-[12px]" style={{ color: "var(--text-3)" }}>
+        {count} 件
+      </span>
+    </h2>
+  );
+}
+
+function authorLabel(name: string | null | undefined): string {
+  // Privacy: never derive a handle from email; keep it to the display name.
+  return name ?? "Anonymous";
+}
+
+function CourseResultRow({ course }: { course: CourseSearchHit }) {
+  const lessonCount = course.lessons.length;
+  return (
+    <Link
+      href={`/courses/${course.slug}`}
+      className="group flex items-start gap-3 rounded-[14px] px-4 py-3 transition hover:border-[color:var(--line-3)]"
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <span
+        aria-hidden="true"
+        className="mt-0.5 inline-flex size-8 shrink-0 items-center justify-center rounded-[8px]"
+        style={{ background: "var(--bg-2)", color: "var(--text-2)" }}
+      >
+        <BookText className="size-4" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span
+          className="truncate font-semibold text-[14px] tracking-tight"
+          style={{ color: "var(--text-1)" }}
+        >
+          {course.title}
+        </span>
+        {course.description ? (
+          <span className="line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
+            {course.description}
+          </span>
+        ) : null}
+        <span
+          className="flex items-center gap-3 pt-0.5 text-[11.5px]"
+          style={{ color: "var(--text-4)" }}
+        >
+          <span>{authorLabel(course.author?.name)}</span>
+          <span aria-hidden="true">・</span>
+          <span>
+            <b style={{ color: "var(--text-2)" }}>{lessonCount}</b> レッスン
+          </span>
+        </span>
+      </span>
+    </Link>
+  );
+}
+
+function LessonResultRow({ lesson }: { lesson: LessonSearchHit }) {
+  return (
+    <Link
+      href={`/courses/${lesson.course.slug}/lessons/${lesson.slug}`}
+      className="group flex items-start gap-3 rounded-[14px] px-4 py-3 transition hover:border-[color:var(--line-3)]"
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <span
+        aria-hidden="true"
+        className="mt-0.5 inline-flex size-8 shrink-0 items-center justify-center rounded-[8px]"
+        style={{ background: "var(--bg-2)", color: "var(--text-2)" }}
+      >
+        <FileText className="size-4" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span
+          className="truncate font-semibold text-[14px] tracking-tight"
+          style={{ color: "var(--text-1)" }}
+        >
+          {lesson.title}
+        </span>
+        <span className="flex items-center gap-3 text-[11.5px]" style={{ color: "var(--text-4)" }}>
+          <span className="truncate" style={{ color: "var(--text-3)" }}>
+            {lesson.course.title}
+          </span>
+          <span aria-hidden="true">・</span>
+          <span>{authorLabel(lesson.course.author?.name)}</span>
+        </span>
+      </span>
+    </Link>
+  );
+}
+
+function EmptyState({ title, description }: { title: string; description: string }) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 rounded-[14px] px-8 py-14 text-center"
+      style={{
+        background: "var(--bg-1)",
+        border: "1px dashed var(--line-3)",
+        color: "var(--text-3)",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex size-10 items-center justify-center rounded-full"
+        style={{ background: "var(--bg-2)", color: "var(--text-2)" }}
+      >
+        <SearchIcon className="size-5" />
+      </span>
+      <p className="m-0 font-semibold text-[14px]" style={{ color: "var(--text-1)" }}>
+        {title}
+      </p>
+      <p className="m-0 text-[12.5px]">{description}</p>
+    </div>
+  );
+}

--- a/src/app/(protected)/search/page.tsx
+++ b/src/app/(protected)/search/page.tsx
@@ -2,7 +2,7 @@ import { BookText, FileText, Search as SearchIcon } from "lucide-react";
 import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 import type { CourseSearchHit, LessonSearchHit } from "@/repositories";
-import { search } from "@/services/searchService";
+import { MIN_QUERY_LENGTH, search } from "@/services/searchService";
 
 export const dynamic = "force-dynamic";
 
@@ -15,18 +15,23 @@ export default async function SearchPage({ searchParams }: PageProps<"/search">)
   await requireAuth();
   const sp = await searchParams;
   const rawQuery = firstParam(sp?.q);
-  const { query, courses, lessons } = await search(rawQuery);
+  const { query, tooShort, courses, lessons } = await search(rawQuery);
   const hasQuery = query.length > 0;
   const totalHits = courses.length + lessons.length;
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
-      <Header query={query} hasQuery={hasQuery} totalHits={totalHits} />
+      <Header query={query} hasQuery={hasQuery && !tooShort} totalHits={totalHits} />
 
       {!hasQuery ? (
         <EmptyState
           title="検索キーワードを入力してください"
           description="上部の検索バーにコース名やレッスン名、本文のキーワードを入力して Enter。"
+        />
+      ) : tooShort ? (
+        <EmptyState
+          title={`${MIN_QUERY_LENGTH} 文字以上で検索してください`}
+          description="短すぎるキーワードは検索対象外です。"
         />
       ) : totalHits === 0 ? (
         <EmptyState

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -4,11 +4,13 @@ import { CourseRepository } from "./course.repository";
 import { LessonRepository } from "./lesson.repository";
 import { ProfileRepository } from "./profile.repository";
 import { ProgressRepository } from "./progress.repository";
+import { SearchRepository } from "./search.repository";
 
 export const courseRepository = new CourseRepository();
 export const lessonRepository = new LessonRepository();
 export const profileRepository = new ProfileRepository();
 export const progressRepository = new ProgressRepository();
+export const searchRepository = new SearchRepository();
 
 export type {
   CourseAuthor,
@@ -19,4 +21,11 @@ export type {
   UpdateCourseInput,
 } from "./course.repository";
 export type { CreateLessonInput, UpdateLessonInput } from "./lesson.repository";
-export { CourseRepository, LessonRepository, ProfileRepository, ProgressRepository };
+export type { CourseSearchHit, LessonSearchHit } from "./search.repository";
+export {
+  CourseRepository,
+  LessonRepository,
+  ProfileRepository,
+  ProgressRepository,
+  SearchRepository,
+};

--- a/src/repositories/search.repository.ts
+++ b/src/repositories/search.repository.ts
@@ -1,0 +1,75 @@
+import "server-only";
+
+import type { Prisma } from "@prisma/client";
+import { BaseRepository } from "./base.repository";
+
+export type CourseSearchHit = Prisma.CourseGetPayload<{
+  include: {
+    author: { select: { id: true; name: true; avatarUrl: true } };
+    lessons: { where: { isPublished: true }; select: { id: true } };
+  };
+}>;
+
+export type LessonSearchHit = Prisma.LessonGetPayload<{
+  include: {
+    course: {
+      select: {
+        id: true;
+        slug: true;
+        title: true;
+        author: { select: { id: true; name: true } };
+      };
+    };
+  };
+}>;
+
+const SEARCH_LIMIT = 20;
+
+export class SearchRepository extends BaseRepository {
+  async searchCourses(query: string): Promise<CourseSearchHit[]> {
+    return this.client.course.findMany({
+      where: {
+        isPublished: true,
+        OR: [
+          { title: { contains: query, mode: "insensitive" } },
+          { description: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      orderBy: { createdAt: "desc" },
+      take: SEARCH_LIMIT,
+      include: {
+        author: { select: { id: true, name: true, avatarUrl: true } },
+        lessons: {
+          where: { isPublished: true },
+          select: { id: true },
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+  }
+
+  async searchLessons(query: string): Promise<LessonSearchHit[]> {
+    return this.client.lesson.findMany({
+      where: {
+        isPublished: true,
+        course: { isPublished: true },
+        OR: [
+          { title: { contains: query, mode: "insensitive" } },
+          { contentMd: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      orderBy: { createdAt: "desc" },
+      take: SEARCH_LIMIT,
+      include: {
+        course: {
+          select: {
+            id: true,
+            slug: true,
+            title: true,
+            author: { select: { id: true, name: true } },
+          },
+        },
+      },
+    });
+  }
+}

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { handleUnknownError } from "@/lib/errors";
+import { logError, logInfo } from "@/lib/logging";
+import {
+  type CourseSearchHit,
+  type LessonSearchHit,
+  type SearchRepository,
+  searchRepository,
+} from "@/repositories";
+
+export type SearchResults = {
+  query: string;
+  courses: CourseSearchHit[];
+  lessons: LessonSearchHit[];
+};
+
+// Single-character queries explode the ILIKE cost and match nearly everything,
+// so require at least 2 characters before hitting the repository.
+const MIN_QUERY_LENGTH = 2;
+
+export async function search(
+  query: string,
+  repository: SearchRepository = searchRepository,
+): Promise<SearchResults> {
+  const trimmed = query.trim();
+  if (trimmed.length < MIN_QUERY_LENGTH) {
+    return { query: trimmed, courses: [], lessons: [] };
+  }
+
+  logInfo("searchService.search.start", { query: trimmed });
+  try {
+    const [courses, lessons] = await Promise.all([
+      repository.searchCourses(trimmed),
+      repository.searchLessons(trimmed),
+    ]);
+    logInfo("searchService.search.success", {
+      query: trimmed,
+      courseCount: courses.length,
+      lessonCount: lessons.length,
+    });
+    return { query: trimmed, courses, lessons };
+  } catch (error) {
+    logError("searchService.search.error", { query: trimmed }, error);
+    throw handleUnknownError(error);
+  }
+}

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -11,37 +11,45 @@ import {
 
 export type SearchResults = {
   query: string;
+  // Distinguishes "we skipped the search because the query is too short" from
+  // "we searched but found nothing" — the UI renders different empty states.
+  tooShort: boolean;
   courses: CourseSearchHit[];
   lessons: LessonSearchHit[];
 };
 
 // Single-character queries explode the ILIKE cost and match nearly everything,
 // so require at least 2 characters before hitting the repository.
-const MIN_QUERY_LENGTH = 2;
+export const MIN_QUERY_LENGTH = 2;
 
 export async function search(
   query: string,
   repository: SearchRepository = searchRepository,
 ): Promise<SearchResults> {
   const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return { query: trimmed, tooShort: false, courses: [], lessons: [] };
+  }
   if (trimmed.length < MIN_QUERY_LENGTH) {
-    return { query: trimmed, courses: [], lessons: [] };
+    return { query: trimmed, tooShort: true, courses: [], lessons: [] };
   }
 
-  logInfo("searchService.search.start", { query: trimmed });
+  // Log only the query length — raw search terms can be PII-adjacent and our
+  // logging policy forbids sensitive payloads.
+  logInfo("searchService.search.start", { queryLength: trimmed.length });
   try {
     const [courses, lessons] = await Promise.all([
       repository.searchCourses(trimmed),
       repository.searchLessons(trimmed),
     ]);
     logInfo("searchService.search.success", {
-      query: trimmed,
+      queryLength: trimmed.length,
       courseCount: courses.length,
       lessonCount: lessons.length,
     });
-    return { query: trimmed, courses, lessons };
+    return { query: trimmed, tooShort: false, courses, lessons };
   } catch (error) {
-    logError("searchService.search.error", { query: trimmed }, error);
+    logError("searchService.search.error", { queryLength: trimmed.length }, error);
     throw handleUnknownError(error);
   }
 }


### PR DESCRIPTION
## Summary

- `/search?q=...` で Course と Lesson を横断検索する機能を追加
- Repository → Service → Server Component (Server Component + searchParams パターン)
- TopBar の検索バー (#48 で disabled 設置済み) を form submit で `/search` に遷移するように活性化

## 実装詳細

- `SearchRepository` — `title` / `description` / `contentMd` に対する `contains` + `mode: "insensitive"`。`isPublished: true` のみ、Lesson は parent Course も `isPublished: true` 必須。件数上限 20
- `searchService.search(q)` — 2 文字未満は即空結果を返却 (ILIKE の full-scan 回避)。Course / Lesson 取得は `Promise.all` で並列
- `/search` ページ — Server Component、上部にコース、下部にレッスン。クエリ無し / 結果 0 件も friendly state で描画
- TopBar — `<form action="/search" method="get">` の GET 遷移。JS なしでも動作。`/search` 上では URL の `q` で input を pre-fill

## 制約

- schema 変更なし (既存 fields で完結)
- Repository 層のみ Prisma を直 import (architecture.md 遵守)
- 新規ディレクトリは `src/app/(protected)/search/` のみ

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)