### PR TITLE
feat(db): Add CourseProviderType (official/community split)

### DIFF
--- a/prisma/migrations/20260424132514_add_course_provider_type/migration.sql
+++ b/prisma/migrations/20260424132514_add_course_provider_type/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "CourseProviderType" AS ENUM ('OFFICIAL', 'COMMUNITY');
+
+-- AlterTable: add provider_type column. Default COMMUNITY so new UGC rows
+-- are classified correctly without the author having to specify it.
+ALTER TABLE "Course" ADD COLUMN     "provider_type" "CourseProviderType" NOT NULL DEFAULT 'COMMUNITY';
+
+-- CreateIndex
+CREATE INDEX "Course_provider_type_idx" ON "Course"("provider_type");
+
+-- Backfill: pre-UGC rows (seed content) have no author_id set, so classify
+-- them as OFFICIAL. UGC rows created after the app gained an authorId field
+-- always have author_id set and keep the COMMUNITY default.
+UPDATE "Course" SET "provider_type" = 'OFFICIAL' WHERE "author_id" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,20 +7,27 @@ datasource db {
 }
 
 model Course {
-  id          String   @id @default(cuid())
-  slug        String   @unique
-  title       String
-  description String
-  order       Int
-  authorId    String?  @db.Uuid @map("author_id")
-  author      Profile? @relation(fields: [authorId], references: [id], onDelete: SetNull)
-  isPublished Boolean  @default(false) @map("is_published")
-  lessons     Lesson[]
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt @map("updated_at")
+  id           String             @id @default(cuid())
+  slug         String             @unique
+  title        String
+  description  String
+  order        Int
+  authorId     String?            @db.Uuid @map("author_id")
+  author       Profile?           @relation(fields: [authorId], references: [id], onDelete: SetNull)
+  isPublished  Boolean            @default(false) @map("is_published")
+  providerType CourseProviderType @default(COMMUNITY) @map("provider_type")
+  lessons      Lesson[]
+  createdAt    DateTime           @default(now())
+  updatedAt    DateTime           @updatedAt @map("updated_at")
 
   @@index([authorId])
   @@index([isPublished])
+  @@index([providerType])
+}
+
+enum CourseProviderType {
+  OFFICIAL
+  COMMUNITY
 }
 
 model Lesson {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -840,6 +840,7 @@ async function main() {
         description: course.description,
         order: course.order,
         isPublished: true,
+        providerType: "OFFICIAL",
         lessons: {
           create: course.lessons.map((l) => ({
             slug: l.slug,

--- a/src/app/(protected)/explore/page.tsx
+++ b/src/app/(protected)/explore/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth } from "@/lib/auth";
-import { getPublishedCoursesByNewest } from "@/services/courseService";
+import { getCommunityPublishedCoursesByNewest } from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
 import { BrowseFilterPanel } from "../_components/BrowseFilterPanel";
 import { BrowseToolbar, type SortOption } from "../_components/BrowseToolbar";
@@ -17,7 +17,7 @@ const EXPLORE_SORT_OPTIONS: ReadonlyArray<SortOption> = [
 export default async function ExplorePage() {
   const session = await requireAuth();
   const [courses, completed] = await Promise.all([
-    getPublishedCoursesByNewest(),
+    getCommunityPublishedCoursesByNewest(),
     getCompletedLessonIdsByUser(session.userId),
   ]);
   const completedIds = new Set(completed);

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -1,23 +1,18 @@
 import { requireAuth } from "@/lib/auth";
-import { getCoursesWithLessons } from "@/services/courseService";
+import {
+  getCommunityPublishedCoursesByNewest,
+  getOfficialPublishedCourses,
+} from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
-import { BrowseFilterPanel } from "./_components/BrowseFilterPanel";
-import { BrowseToolbar, type SortOption } from "./_components/BrowseToolbar";
 import { CourseCard } from "./_components/CourseCard";
 
 export const dynamic = "force-dynamic";
 
-const LEARN_SORT_OPTIONS: ReadonlyArray<SortOption> = [
-  { key: "recommended", label: "おすすめ" },
-  { key: "newest", label: "新着" },
-  { key: "popular", label: "人気" },
-  { key: "ac-rate", label: "AC率高" },
-];
-
 export default async function Home() {
   const session = await requireAuth();
-  const [courses, completed] = await Promise.all([
-    getCoursesWithLessons(),
+  const [official, community, completed] = await Promise.all([
+    getOfficialPublishedCourses(),
+    getCommunityPublishedCoursesByNewest(),
     getCompletedLessonIdsByUser(session.userId),
   ]);
 
@@ -25,42 +20,84 @@ export default async function Home() {
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
-      <header className="mb-7">
-        <h1 className="m-0 font-bold text-[26px] tracking-tight">学ぶ — キュレーションコース</h1>
-        <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
-          公式が厳選した TypeScript の学習コース
-        </p>
-      </header>
+      <section>
+        <div className="mb-4">
+          <h1 className="m-0 font-semibold text-[22px] tracking-tight">公式コース</h1>
+          <span className="text-xs" style={{ color: "var(--text-3)" }}>
+            codelearn が提供する TypeScript コース
+          </span>
+        </div>
 
-      <div className="grid grid-cols-1 gap-7 md:grid-cols-[240px_minmax(0,1fr)]">
-        <BrowseFilterPanel ariaLabel="フィルタ (学ぶ / UI プレビュー)" />
-        <main className="min-w-0">
-          <BrowseToolbar
-            total={courses.length}
-            sortOptions={LEARN_SORT_OPTIONS}
-            activeSortKey="recommended"
-          />
-          {courses.length === 0 ? (
-            <EmptyCourses />
-          ) : (
-            <ul
-              className="grid gap-4"
-              style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
-            >
-              {courses.map((course, idx) => (
-                <li key={course.id}>
-                  <CourseCard course={course} index={idx} completedIds={completedIds} />
-                </li>
-              ))}
-            </ul>
-          )}
-        </main>
-      </div>
+        {official.length === 0 ? (
+          <EmptyCourses variant="official" />
+        ) : (
+          <CourseGrid>
+            {official.map((c, idx) => (
+              <li key={c.id}>
+                <CourseCard course={c} index={idx} completedIds={completedIds} />
+              </li>
+            ))}
+          </CourseGrid>
+        )}
+      </section>
+
+      <section className="mt-12">
+        <div className="mb-4">
+          <h2 className="m-0 font-semibold text-[22px] tracking-tight">コミュニティコース</h2>
+          <span className="text-xs" style={{ color: "var(--text-3)" }}>
+            ユーザーが投稿した新着コース
+          </span>
+        </div>
+
+        {community.length === 0 ? (
+          <EmptyCourses variant="community" />
+        ) : (
+          <CourseGrid>
+            {community.map((c, idx) => (
+              <li key={c.id}>
+                <CourseCard course={c} index={idx} completedIds={completedIds} />
+              </li>
+            ))}
+          </CourseGrid>
+        )}
+      </section>
     </div>
   );
 }
 
-function EmptyCourses() {
+function CourseGrid({ children }: { children: React.ReactNode }) {
+  return (
+    <ul
+      className="grid gap-4"
+      style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
+    >
+      {children}
+    </ul>
+  );
+}
+
+function EmptyCourses({ variant }: { variant: "official" | "community" }) {
+  if (variant === "official") {
+    return (
+      <div
+        className="rounded-[14px] px-8 py-12 text-center text-[13px]"
+        style={{
+          background: "var(--bg-1)",
+          border: "1px dashed var(--line-3)",
+          color: "var(--text-3)",
+        }}
+      >
+        公式コースがまだありません。
+        <code
+          className="mx-1 rounded px-2 py-0.5 text-[12px]"
+          style={{ background: "var(--bg-2)", color: "var(--accent-solid)" }}
+        >
+          npm run db:seed
+        </code>
+        を実行してください。
+      </div>
+    );
+  }
   return (
     <div
       className="rounded-[14px] px-8 py-12 text-center text-[13px]"
@@ -70,14 +107,7 @@ function EmptyCourses() {
         color: "var(--text-3)",
       }}
     >
-      まだコースがありません。
-      <code
-        className="mx-1 rounded px-2 py-0.5 text-[12px]"
-        style={{ background: "var(--bg-2)", color: "var(--accent-solid)" }}
-      >
-        npm run db:seed
-      </code>
-      を実行してください。
+      コミュニティコースはまだ投稿されていません。
     </div>
   );
 }

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -80,6 +80,37 @@ export class CourseRepository extends BaseRepository {
     });
   }
 
+  async findOfficialPublished(): Promise<CourseWithLessonIds[]> {
+    return this.client.course.findMany({
+      where: { isPublished: true, providerType: "OFFICIAL" },
+      orderBy: { order: "asc" },
+      include: {
+        lessons: {
+          where: { isPublished: true },
+          select: { id: true },
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+  }
+
+  async findCommunityPublishedByNewest(): Promise<CourseWithLessonsAndAuthor[]> {
+    return this.client.course.findMany({
+      where: { isPublished: true, providerType: "COMMUNITY" },
+      orderBy: { createdAt: "desc" },
+      include: {
+        lessons: {
+          where: { isPublished: true },
+          select: { id: true },
+          orderBy: { order: "asc" },
+        },
+        author: {
+          select: { id: true, email: true, name: true, avatarUrl: true },
+        },
+      },
+    });
+  }
+
   async findBySlugWithLessons(slug: string): Promise<CourseWithLessons | null> {
     return this.client.course.findUnique({
       where: { slug },

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -80,7 +80,7 @@ export class CourseRepository extends BaseRepository {
     });
   }
 
-  async findOfficialPublished(): Promise<CourseWithLessonIds[]> {
+  async findOfficialPublished(): Promise<CourseWithLessonsAndAuthor[]> {
     return this.client.course.findMany({
       where: { isPublished: true, providerType: "OFFICIAL" },
       orderBy: { order: "asc" },
@@ -89,6 +89,9 @@ export class CourseRepository extends BaseRepository {
           where: { isPublished: true },
           select: { id: true },
           orderBy: { order: "asc" },
+        },
+        author: {
+          select: { id: true, email: true, name: true, avatarUrl: true },
         },
       },
     });

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -42,7 +42,7 @@ export async function getPublishedCoursesByNewest(
 
 export async function getOfficialPublishedCourses(
   repository: CourseRepository = courseRepository,
-): Promise<CourseWithLessonIds[]> {
+): Promise<CourseWithLessonsAndAuthor[]> {
   logInfo("courseService.getOfficialPublishedCourses.start");
   try {
     const result = await repository.findOfficialPublished();

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -40,6 +40,36 @@ export async function getPublishedCoursesByNewest(
   }
 }
 
+export async function getOfficialPublishedCourses(
+  repository: CourseRepository = courseRepository,
+): Promise<CourseWithLessonIds[]> {
+  logInfo("courseService.getOfficialPublishedCourses.start");
+  try {
+    const result = await repository.findOfficialPublished();
+    logInfo("courseService.getOfficialPublishedCourses.success", { count: result.length });
+    return result;
+  } catch (error) {
+    logError("courseService.getOfficialPublishedCourses.error", undefined, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function getCommunityPublishedCoursesByNewest(
+  repository: CourseRepository = courseRepository,
+): Promise<CourseWithLessonsAndAuthor[]> {
+  logInfo("courseService.getCommunityPublishedCoursesByNewest.start");
+  try {
+    const result = await repository.findCommunityPublishedByNewest();
+    logInfo("courseService.getCommunityPublishedCoursesByNewest.success", {
+      count: result.length,
+    });
+    return result;
+  } catch (error) {
+    logError("courseService.getCommunityPublishedCoursesByNewest.error", undefined, error);
+    throw handleUnknownError(error);
+  }
+}
+
 export async function getCourseBySlug(
   slug: string,
   repository: CourseRepository = courseRepository,


### PR DESCRIPTION
## Summary

- `Course` に `providerType: CourseProviderType (OFFICIAL | COMMUNITY)` を追加し、seed 由来の公式コースと UGC を区別できるようにする (#52)。
- Home を「公式 / コミュニティ」の 2 セクションに分割。Explore はコミュニティのみを対象にし、`providerType` フィルタの placeholder を disabled UI で追加。
- Migration は `author_id IS NULL` のコースを `OFFICIAL` に backfill する。ユーザー側 (Supabase) への apply はこの PR のスコープ外。

## Changes

- `prisma/schema.prisma`: `CourseProviderType` enum 追加・`@@index([providerType])`
- `prisma/migrations/20260424132514_add_course_provider_type/`: enum 作成 + 列追加 + backfill
- `prisma/seed.ts`: seed コースを `providerType: "OFFICIAL"` で明示
- `src/repositories/course.repository.ts`: `findOfficialPublished` / `findCommunityPublishedByNewest` を追加
- `src/services/courseService.ts`: 同名の service 関数を公開
- `src/app/(protected)/page.tsx`: 2 セクション表示 (公式 → コミュニティ)
- `src/app/(protected)/explore/page.tsx`: COMMUNITY のみを listing、filter panel に「提供元」行を disabled で追加

## Test plan

- [x] `npm run check` pass
- [x] `npm run build` pass (placeholder env)
- [x] `npx prisma migrate diff --from-migrations … --to-schema …` で "No difference detected"
- [ ] ユーザー側で Supabase に migration apply + seed 再実行 → Home に公式 / コミュニティが分かれて表示されることを確認

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)