### PR TITLE
feat(notifications): Bell UI + notification center

### DIFF
--- a/prisma/migrations/20260424140229_add_notifications/migration.sql
+++ b/prisma/migrations/20260424140229_add_notifications/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('SYSTEM', 'COURSE_LIKED', 'COMMENT', 'FOLLOW');
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "recipient_id" UUID NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT,
+    "link_url" TEXT,
+    "read_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "notifications_recipient_id_created_at_idx" ON "notifications"("recipient_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "notifications_recipient_id_read_at_idx" ON "notifications"("recipient_id", "read_at");
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_recipient_id_fkey" FOREIGN KEY ("recipient_id") REFERENCES "profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,14 +62,38 @@ model Progress {
 }
 
 model Profile {
-  id        String     @id @db.Uuid
-  email     String?
-  name      String?
-  avatarUrl String?    @map("avatar_url")
-  createdAt DateTime   @default(now()) @map("created_at")
-  updatedAt DateTime   @updatedAt      @map("updated_at")
-  progress  Progress[]
-  courses   Course[]
+  id            String         @id @db.Uuid
+  email         String?
+  name          String?
+  avatarUrl     String?        @map("avatar_url")
+  createdAt     DateTime       @default(now()) @map("created_at")
+  updatedAt     DateTime       @updatedAt      @map("updated_at")
+  progress      Progress[]
+  courses       Course[]
+  notifications Notification[]
 
   @@map("profiles")
+}
+
+enum NotificationType {
+  SYSTEM
+  COURSE_LIKED
+  COMMENT
+  FOLLOW
+}
+
+model Notification {
+  id          String           @id @default(cuid())
+  recipientId String           @db.Uuid @map("recipient_id")
+  recipient   Profile          @relation(fields: [recipientId], references: [id], onDelete: Cascade)
+  type        NotificationType
+  title       String
+  body        String?          @db.Text
+  linkUrl     String?          @map("link_url")
+  readAt      DateTime?        @map("read_at")
+  createdAt   DateTime         @default(now()) @map("created_at")
+
+  @@index([recipientId, createdAt])
+  @@index([recipientId, readAt])
+  @@map("notifications")
 }

--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { actionClient } from "@/lib/safe-action";
+import { markAllAsRead, markAsRead } from "@/services/notificationService";
+
+const MarkAsReadSchema = z.object({
+  id: z.cuid(),
+});
+
+export const markNotificationAsReadAction = actionClient
+  .inputSchema(MarkAsReadSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    await markAsRead({ id: parsedInput.id, userId: ctx.userId });
+    revalidatePath("/notifications");
+    revalidatePath("/", "layout");
+    return { ok: true as const };
+  });
+
+export const markAllNotificationsAsReadAction = actionClient
+  .inputSchema(z.object({}))
+  .action(async ({ ctx }) => {
+    const count = await markAllAsRead(ctx.userId);
+    revalidatePath("/notifications");
+    revalidatePath("/", "layout");
+    return { ok: true as const, count };
+  });

--- a/src/app/(protected)/_components/TopBar.tsx
+++ b/src/app/(protected)/_components/TopBar.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 type Props = {
   displayName: string;
   avatarInitial: string;
+  unreadCount: number;
 };
 
 type NavGroup = "learn" | "explore" | "create" | null;
@@ -21,11 +22,14 @@ function resolveNavGroup(pathname: string): NavGroup {
   return null;
 }
 
-export function TopBar({ displayName, avatarInitial }: Props) {
+export function TopBar({ displayName, avatarInitial, unreadCount }: Props) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const group = resolveNavGroup(pathname);
   const initialQuery = pathname === "/search" ? (searchParams.get("q") ?? "") : "";
+  const hasUnread = unreadCount > 0;
+  const badgeLabel = unreadCount > 99 ? "99+" : String(unreadCount);
+  const bellAriaLabel = hasUnread ? `通知 (${unreadCount} 件の未読)` : "通知";
 
   return (
     <header
@@ -102,18 +106,28 @@ export function TopBar({ displayName, avatarInitial }: Props) {
             作る
           </NavTab>
         </nav>
-        <button
-          type="button"
-          aria-label="通知"
-          className="relative grid size-9 place-items-center rounded-[10px] transition"
+        <Link
+          href="/notifications"
+          aria-label={bellAriaLabel}
+          aria-current={pathname === "/notifications" ? "page" : undefined}
+          className="relative grid size-9 place-items-center rounded-[10px] transition hover:bg-[var(--bg-2)]"
           style={{ color: "var(--text-2)" }}
         >
           <Bell className="size-[18px]" />
-          <span
-            className="absolute top-2 right-2 size-2 rounded-full"
-            style={{ background: "var(--accent-solid)", border: "2px solid var(--bg-0)" }}
-          />
-        </button>
+          {hasUnread ? (
+            <span
+              aria-hidden="true"
+              className="absolute top-0.5 right-0.5 inline-flex h-[16px] min-w-[16px] items-center justify-center rounded-full px-1 font-semibold text-[10px] leading-none"
+              style={{
+                background: "var(--accent-solid)",
+                color: "var(--bg-0)",
+                border: "2px solid var(--bg-0)",
+              }}
+            >
+              {badgeLabel}
+            </span>
+          ) : null}
+        </Link>
         <Link
           href="/me"
           className="cm-avatar"

--- a/src/app/(protected)/_components/TopBarSwitcher.tsx
+++ b/src/app/(protected)/_components/TopBarSwitcher.tsx
@@ -6,6 +6,7 @@ import { TopBar } from "./TopBar";
 type Props = {
   displayName: string;
   avatarInitial: string;
+  unreadCount: number;
 };
 
 export function TopBarSwitcher(props: Props) {

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,14 +1,20 @@
 import { requireAuth } from "@/lib/auth";
+import { getUnreadCount } from "@/services/notificationService";
 import { TopBarSwitcher } from "./_components/TopBarSwitcher";
 
 export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {
   const session = await requireAuth();
   const displayName = session.profile.name ?? session.email ?? session.userId;
   const avatarInitial = (displayName.trim()[0] ?? "?").toUpperCase();
+  const unreadCount = await getUnreadCount(session.userId);
 
   return (
     <>
-      <TopBarSwitcher displayName={displayName} avatarInitial={avatarInitial} />
+      <TopBarSwitcher
+        displayName={displayName}
+        avatarInitial={avatarInitial}
+        unreadCount={unreadCount}
+      />
       {children}
     </>
   );

--- a/src/app/(protected)/notifications/_components/MarkAllAsReadButton.tsx
+++ b/src/app/(protected)/notifications/_components/MarkAllAsReadButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { CheckCheck } from "lucide-react";
+import { useTransition } from "react";
+import { markAllNotificationsAsReadAction } from "@/actions/notifications";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  disabled: boolean;
+};
+
+export function MarkAllAsReadButton({ disabled }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  const onClick = () => {
+    startTransition(async () => {
+      await markAllNotificationsAsReadAction({});
+    });
+  };
+
+  return (
+    <Button
+      disabled={disabled || isPending}
+      onClick={onClick}
+      size="sm"
+      type="button"
+      variant="outline"
+    >
+      <CheckCheck aria-hidden="true" />
+      すべて既読にする
+    </Button>
+  );
+}

--- a/src/app/(protected)/notifications/_components/NotificationRow.tsx
+++ b/src/app/(protected)/notifications/_components/NotificationRow.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type { Notification } from "@prisma/client";
+import { Bell, Heart, MessageSquare, UserPlus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { markNotificationAsReadAction } from "@/actions/notifications";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  notification: Notification;
+};
+
+function typeIcon(type: Notification["type"]) {
+  switch (type) {
+    case "COURSE_LIKED":
+      return Heart;
+    case "COMMENT":
+      return MessageSquare;
+    case "FOLLOW":
+      return UserPlus;
+    default:
+      return Bell;
+  }
+}
+
+function formatRelative(date: Date): string {
+  const now = Date.now();
+  const diffSec = Math.floor((now - date.getTime()) / 1000);
+  if (diffSec < 60) return "たった今";
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)} 分前`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)} 時間前`;
+  if (diffSec < 2592000) return `${Math.floor(diffSec / 86400)} 日前`;
+  return date.toLocaleDateString("ja-JP", { year: "numeric", month: "short", day: "numeric" });
+}
+
+export function NotificationRow({ notification }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const isUnread = notification.readAt === null;
+  const Icon = typeIcon(notification.type);
+
+  const onActivate = () => {
+    startTransition(async () => {
+      if (isUnread) {
+        await markNotificationAsReadAction({ id: notification.id });
+      }
+      if (notification.linkUrl) {
+        router.push(notification.linkUrl);
+      }
+    });
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onActivate();
+    }
+  };
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: row is a composite action (mark-read + optional navigate); native <button> cannot express that mixed role cleanly
+    <div
+      aria-busy={isPending || undefined}
+      aria-label={`${isUnread ? "未読: " : ""}${notification.title}`}
+      className={cn(
+        "relative flex cursor-pointer gap-3 rounded-[14px] px-4 py-3.5 transition hover:bg-[var(--bg-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-solid)]",
+        isPending && "pointer-events-none opacity-60",
+      )}
+      onClick={onActivate}
+      onKeyDown={onKeyDown}
+      role="button"
+      style={{
+        background: isUnread ? "var(--bg-2)" : "var(--bg-1)",
+        border: `1px solid ${isUnread ? "var(--accent-solid)" : "var(--line-1)"}`,
+      }}
+      tabIndex={0}
+    >
+      {isUnread ? (
+        <span
+          aria-hidden="true"
+          className="absolute top-4 left-1.5 size-1.5 rounded-full"
+          style={{ background: "var(--accent-solid)" }}
+        />
+      ) : null}
+      <div
+        aria-hidden="true"
+        className="grid size-9 shrink-0 place-items-center rounded-[10px]"
+        style={{
+          background: isUnread ? "var(--accent-soft)" : "var(--bg-2)",
+          color: isUnread ? "var(--accent-solid)" : "var(--text-3)",
+        }}
+      >
+        <Icon className="size-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-3">
+          <h3
+            className="m-0 truncate font-semibold text-[14px] tracking-tight"
+            style={{ color: "var(--text-1)" }}
+          >
+            {notification.title}
+          </h3>
+          <time
+            className="shrink-0 font-mono text-[11.5px]"
+            dateTime={notification.createdAt.toISOString()}
+            style={{ color: "var(--text-3)" }}
+          >
+            {formatRelative(notification.createdAt)}
+          </time>
+        </div>
+        {notification.body ? (
+          <p
+            className="m-0 mt-1 line-clamp-2 text-[13px] leading-relaxed"
+            style={{ color: "var(--text-2)" }}
+          >
+            {notification.body}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/notifications/page.tsx
+++ b/src/app/(protected)/notifications/page.tsx
@@ -1,0 +1,53 @@
+import { Bell } from "lucide-react";
+import { requireAuth } from "@/lib/auth";
+import { getNotifications } from "@/services/notificationService";
+import { MarkAllAsReadButton } from "./_components/MarkAllAsReadButton";
+import { NotificationRow } from "./_components/NotificationRow";
+
+export const dynamic = "force-dynamic";
+
+export default async function NotificationsPage() {
+  const session = await requireAuth();
+  const notifications = await getNotifications({ userId: session.userId, limit: 50 });
+  const unreadCount = notifications.reduce((acc, n) => (n.readAt === null ? acc + 1 : acc), 0);
+
+  return (
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "960px" }}>
+      <div className="mb-6 flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h1 className="m-0 font-bold text-[22px] tracking-tight">通知</h1>
+          <span className="text-xs" style={{ color: "var(--text-3)" }}>
+            {unreadCount > 0
+              ? `${unreadCount} 件の未読`
+              : notifications.length > 0
+                ? "すべて既読です"
+                : "通知はまだありません"}
+          </span>
+        </div>
+        <MarkAllAsReadButton disabled={unreadCount === 0} />
+      </div>
+
+      {notifications.length === 0 ? (
+        <div
+          className="flex flex-col items-center gap-3 rounded-[14px] px-6 py-16 text-center text-[13px]"
+          style={{
+            background: "var(--bg-1)",
+            border: "1px dashed var(--line-3)",
+            color: "var(--text-3)",
+          }}
+        >
+          <Bell aria-hidden="true" className="size-6" style={{ color: "var(--text-4)" }} />
+          まだ通知はありません。新しい通知が届くとここに表示されます。
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {notifications.map((n) => (
+            <li key={n.id}>
+              <NotificationRow notification={n} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -2,12 +2,14 @@ import "server-only";
 
 import { CourseRepository } from "./course.repository";
 import { LessonRepository } from "./lesson.repository";
+import { NotificationRepository } from "./notification.repository";
 import { ProfileRepository } from "./profile.repository";
 import { ProgressRepository } from "./progress.repository";
 import { SearchRepository } from "./search.repository";
 
 export const courseRepository = new CourseRepository();
 export const lessonRepository = new LessonRepository();
+export const notificationRepository = new NotificationRepository();
 export const profileRepository = new ProfileRepository();
 export const progressRepository = new ProgressRepository();
 export const searchRepository = new SearchRepository();
@@ -21,10 +23,12 @@ export type {
   UpdateCourseInput,
 } from "./course.repository";
 export type { CreateLessonInput, UpdateLessonInput } from "./lesson.repository";
+export type { CreateNotificationInput } from "./notification.repository";
 export type { CourseSearchHit, LessonSearchHit } from "./search.repository";
 export {
   CourseRepository,
   LessonRepository,
+  NotificationRepository,
   ProfileRepository,
   ProgressRepository,
   SearchRepository,

--- a/src/repositories/notification.repository.ts
+++ b/src/repositories/notification.repository.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import type { Notification, NotificationType } from "@prisma/client";
+import { BaseRepository } from "./base.repository";
+
+export type CreateNotificationInput = {
+  recipientId: string;
+  type: NotificationType;
+  title: string;
+  body?: string | null;
+  linkUrl?: string | null;
+};
+
+export class NotificationRepository extends BaseRepository {
+  async findByRecipient(recipientId: string, limit = 20): Promise<Notification[]> {
+    return this.client.notification.findMany({
+      where: { recipientId },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    });
+  }
+
+  async countUnread(recipientId: string): Promise<number> {
+    return this.client.notification.count({
+      where: { recipientId, readAt: null },
+    });
+  }
+
+  async findByIdForRecipient(id: string, recipientId: string): Promise<Notification | null> {
+    return this.client.notification.findFirst({
+      where: { id, recipientId },
+    });
+  }
+
+  // Scoped by recipientId so a user cannot flip someone else's notification.
+  async markAsRead(id: string, recipientId: string): Promise<number> {
+    const result = await this.client.notification.updateMany({
+      where: { id, recipientId, readAt: null },
+      data: { readAt: new Date() },
+    });
+    return result.count;
+  }
+
+  async markAllAsRead(recipientId: string): Promise<number> {
+    const result = await this.client.notification.updateMany({
+      where: { recipientId, readAt: null },
+      data: { readAt: new Date() },
+    });
+    return result.count;
+  }
+
+  async create(input: CreateNotificationInput): Promise<Notification> {
+    return this.client.notification.create({
+      data: {
+        recipientId: input.recipientId,
+        type: input.type,
+        title: input.title,
+        body: input.body ?? null,
+        linkUrl: input.linkUrl ?? null,
+      },
+    });
+  }
+}

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,8 +1,8 @@
 import "server-only";
 
 import type { Notification, NotificationType } from "@prisma/client";
-import { ForbiddenError, handleUnknownError, NotFoundError } from "@/lib/errors";
-import { logError, logInfo } from "@/lib/logging";
+import { ForbiddenError, handleUnknownError, NotFoundError, ValidationError } from "@/lib/errors";
+import { logError, logInfo, logWarn } from "@/lib/logging";
 import { type NotificationRepository, notificationRepository } from "@/repositories";
 
 const DEFAULT_LIMIT = 20;
@@ -105,6 +105,7 @@ export async function createNotification(
     type: params.type,
   });
   try {
+    assertSafeLinkUrl(params.linkUrl);
     const created = await repository.create(params);
     logInfo("notificationService.createNotification.success", {
       id: created.id,
@@ -113,6 +114,13 @@ export async function createNotification(
     });
     return created;
   } catch (error) {
+    if (error instanceof ValidationError) {
+      logWarn("notificationService.createNotification.invalidInput", {
+        recipientId: params.recipientId,
+        type: params.type,
+      });
+      throw error;
+    }
     logError(
       "notificationService.createNotification.error",
       { recipientId: params.recipientId, type: params.type },
@@ -126,4 +134,15 @@ function clampLimit(limit: number | undefined): number {
   if (limit === undefined) return DEFAULT_LIMIT;
   if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT;
   return Math.min(Math.floor(limit), MAX_LIMIT);
+}
+
+// Guard against persisting unsafe URLs that would later be handed to
+// `router.push` on the client. Only app-internal paths are allowed — a leading
+// `/` followed by a non-slash character (rejecting `//host` protocol-relative
+// URLs and `javascript:` / `data:` schemes). Future callers that need to link
+// to a trusted external origin should extend this allowlist explicitly.
+function assertSafeLinkUrl(value: string | null | undefined): void {
+  if (value == null || value === "") return;
+  if (/^\/(?!\/)/.test(value)) return;
+  throw new ValidationError(`Unsafe linkUrl: ${value}`);
 }

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,129 @@
+import "server-only";
+
+import type { Notification, NotificationType } from "@prisma/client";
+import { ForbiddenError, handleUnknownError, NotFoundError } from "@/lib/errors";
+import { logError, logInfo } from "@/lib/logging";
+import { type NotificationRepository, notificationRepository } from "@/repositories";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export async function getNotifications(
+  params: { userId: string; limit?: number },
+  repository: NotificationRepository = notificationRepository,
+): Promise<Notification[]> {
+  const { userId } = params;
+  const limit = clampLimit(params.limit);
+  logInfo("notificationService.getNotifications.start", { userId, limit });
+  try {
+    const notifications = await repository.findByRecipient(userId, limit);
+    logInfo("notificationService.getNotifications.success", {
+      userId,
+      count: notifications.length,
+    });
+    return notifications;
+  } catch (error) {
+    logError("notificationService.getNotifications.error", { userId, limit }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function getUnreadCount(
+  userId: string,
+  repository: NotificationRepository = notificationRepository,
+): Promise<number> {
+  logInfo("notificationService.getUnreadCount.start", { userId });
+  try {
+    const count = await repository.countUnread(userId);
+    logInfo("notificationService.getUnreadCount.success", { userId, count });
+    return count;
+  } catch (error) {
+    logError("notificationService.getUnreadCount.error", { userId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function markAsRead(
+  params: { id: string; userId: string },
+  repository: NotificationRepository = notificationRepository,
+): Promise<void> {
+  const { id, userId } = params;
+  logInfo("notificationService.markAsRead.start", { id, userId });
+  try {
+    // Two-step: look up ownership to distinguish "not found" vs "not yours"
+    // vs "already read". markAsRead's updateMany filters by both id and
+    // recipientId and returns 0 for any of those cases, so we need the
+    // lookup to return the correct error shape.
+    const existing = await repository.findByIdForRecipient(id, userId);
+    if (!existing) {
+      // Also covers the case where the notification exists but belongs to
+      // someone else — findByIdForRecipient filters by recipientId, so the
+      // caller cannot tell the two apart. Return NotFoundError either way
+      // (avoid leaking existence of other users' notifications).
+      throw new NotFoundError(`Notification not found: ${id}`);
+    }
+    await repository.markAsRead(id, userId);
+    logInfo("notificationService.markAsRead.success", { id, userId });
+  } catch (error) {
+    if (error instanceof NotFoundError || error instanceof ForbiddenError) throw error;
+    logError("notificationService.markAsRead.error", { id, userId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function markAllAsRead(
+  userId: string,
+  repository: NotificationRepository = notificationRepository,
+): Promise<number> {
+  logInfo("notificationService.markAllAsRead.start", { userId });
+  try {
+    const count = await repository.markAllAsRead(userId);
+    logInfo("notificationService.markAllAsRead.success", { userId, count });
+    return count;
+  } catch (error) {
+    logError("notificationService.markAllAsRead.error", { userId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export type CreateNotificationParams = {
+  recipientId: string;
+  type: NotificationType;
+  title: string;
+  body?: string | null;
+  linkUrl?: string | null;
+};
+
+// Wrapper intended for future call sites (comments / likes / follows) so those
+// services don't reach into the notification repository directly.
+export async function createNotification(
+  params: CreateNotificationParams,
+  repository: NotificationRepository = notificationRepository,
+): Promise<Notification> {
+  logInfo("notificationService.createNotification.start", {
+    recipientId: params.recipientId,
+    type: params.type,
+  });
+  try {
+    const created = await repository.create(params);
+    logInfo("notificationService.createNotification.success", {
+      id: created.id,
+      recipientId: created.recipientId,
+      type: created.type,
+    });
+    return created;
+  } catch (error) {
+    logError(
+      "notificationService.createNotification.error",
+      { recipientId: params.recipientId, type: params.type },
+      error,
+    );
+    throw handleUnknownError(error);
+  }
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_LIMIT;
+  if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(limit), MAX_LIMIT);
+}


### PR DESCRIPTION
## Summary

- Add generic `Notification` table (SYSTEM / COURSE_LIKED / COMMENT / FOLLOW) + migration, plus `Profile.notifications` backref
- Repository → service → safe-action wiring for `getNotifications` / `getUnreadCount` / `markAsRead` / `markAllAsRead` / `createNotification`
- TopBar bell is now a link to `/notifications` with a numeric unread badge; added `/notifications` page with per-row mark-as-read, optional link-url follow-through, and "すべて既読にする" control

Ownership is enforced in both the repository (update-scoped by recipientId) and the service (lookup before mark) so one user cannot flip another's notification.

## Test plan

- [ ] Apply migration on shadow DB and confirm table / indexes / FK created as expected
- [ ] Seed a SYSTEM notification manually; confirm badge count on TopBar
- [ ] Click a notification → read state flips, badge decrements, navigates to `linkUrl` when present
- [ ] "すべて既読にする" clears badge in one shot
- [ ] Attempt to mark another user's notification via devtools-crafted action call → server throws NotFound (no cross-user leak)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)