### PR TITLE
feat(bookmarks): Course/Lesson のお気に入り機能

### DIFF
--- a/prisma/migrations/20260424130000_add_bookmarks/migration.sql
+++ b/prisma/migrations/20260424130000_add_bookmarks/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "bookmarks" (
+    "id" TEXT NOT NULL,
+    "user_id" UUID NOT NULL,
+    "course_id" TEXT,
+    "lesson_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "bookmarks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "bookmarks_user_id_course_id_key" ON "bookmarks"("user_id", "course_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "bookmarks_user_id_lesson_id_key" ON "bookmarks"("user_id", "lesson_id");
+
+-- CreateIndex
+CREATE INDEX "bookmarks_user_id_idx" ON "bookmarks"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "bookmarks" ADD CONSTRAINT "bookmarks_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bookmarks" ADD CONSTRAINT "bookmarks_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bookmarks" ADD CONSTRAINT "bookmarks_lesson_id_fkey" FOREIGN KEY ("lesson_id") REFERENCES "Lesson"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CHECK constraint: exactly one of course_id / lesson_id must be non-null.
+-- Prisma schema cannot express this; enforced at the DB level so bad rows
+-- cannot be inserted even if an application bug slips through.
+ALTER TABLE "bookmarks"
+    ADD CONSTRAINT "bookmarks_target_xor"
+    CHECK (("course_id" IS NULL) <> ("lesson_id" IS NULL));

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model Course {
   isPublished  Boolean            @default(false) @map("is_published")
   providerType CourseProviderType @default(COMMUNITY) @map("provider_type")
   lessons      Lesson[]
+  bookmarks    Bookmark[]
   createdAt    DateTime           @default(now())
   updatedAt    DateTime           @updatedAt @map("updated_at")
 
@@ -42,6 +43,7 @@ model Lesson {
   order          Int
   isPublished    Boolean    @default(false) @map("is_published")
   progress       Progress[]
+  bookmarks      Bookmark[]
   createdAt      DateTime   @default(now())
   updatedAt      DateTime   @updatedAt @map("updated_at")
 
@@ -71,6 +73,7 @@ model Profile {
   progress      Progress[]
   courses       Course[]
   notifications Notification[]
+  bookmarks     Bookmark[]
 
   @@map("profiles")
 }
@@ -96,4 +99,20 @@ model Notification {
   @@index([recipientId, createdAt])
   @@index([recipientId, readAt])
   @@map("notifications")
+}
+
+model Bookmark {
+  id        String   @id @default(cuid())
+  userId    String   @db.Uuid @map("user_id")
+  user      Profile  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  courseId  String?  @map("course_id")
+  course    Course?  @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  lessonId  String?  @map("lesson_id")
+  lesson    Lesson?  @relation(fields: [lessonId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([userId, courseId], name: "user_course_bookmark")
+  @@unique([userId, lessonId], name: "user_lesson_bookmark")
+  @@index([userId])
+  @@map("bookmarks")
 }

--- a/src/actions/bookmarks.ts
+++ b/src/actions/bookmarks.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { actionClient } from "@/lib/safe-action";
+import { toggleCourseBookmark, toggleLessonBookmark } from "@/services/bookmarkService";
+
+const ToggleCourseBookmarkSchema = z.object({
+  courseId: z.cuid(),
+});
+
+const ToggleLessonBookmarkSchema = z.object({
+  lessonId: z.cuid(),
+});
+
+export const toggleCourseBookmarkAction = actionClient
+  .inputSchema(ToggleCourseBookmarkSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const result = await toggleCourseBookmark({
+      userId: ctx.userId,
+      courseId: parsedInput.courseId,
+    });
+    revalidatePath("/bookmarks");
+    return result;
+  });
+
+export const toggleLessonBookmarkAction = actionClient
+  .inputSchema(ToggleLessonBookmarkSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const result = await toggleLessonBookmark({
+      userId: ctx.userId,
+      lessonId: parsedInput.lessonId,
+    });
+    revalidatePath("/bookmarks");
+    return result;
+  });

--- a/src/actions/bookmarks.ts
+++ b/src/actions/bookmarks.ts
@@ -20,7 +20,7 @@ export const toggleCourseBookmarkAction = actionClient
       userId: ctx.userId,
       courseId: parsedInput.courseId,
     });
-    revalidatePath("/bookmarks");
+    revalidatePath("/", "layout");
     return result;
   });
 
@@ -31,6 +31,6 @@ export const toggleLessonBookmarkAction = actionClient
       userId: ctx.userId,
       lessonId: parsedInput.lessonId,
     });
-    revalidatePath("/bookmarks");
+    revalidatePath("/", "layout");
     return result;
   });

--- a/src/app/(protected)/bookmarks/page.tsx
+++ b/src/app/(protected)/bookmarks/page.tsx
@@ -1,0 +1,192 @@
+import { BookText, Star } from "lucide-react";
+import Link from "next/link";
+import { requireAuth } from "@/lib/auth";
+import { cn } from "@/lib/utils";
+import { getUserBookmarks } from "@/services/bookmarkService";
+
+export const dynamic = "force-dynamic";
+
+const COVER_VARIANTS = [
+  "cm-cover-1",
+  "cm-cover-2",
+  "cm-cover-3",
+  "cm-cover-4",
+  "cm-cover-5",
+  "cm-cover-6",
+] as const;
+
+function coverFor(index: number) {
+  return COVER_VARIANTS[index % COVER_VARIANTS.length];
+}
+
+function glyphFor(title: string) {
+  const trimmed = title.trim();
+  if (!trimmed) return "TS";
+  return Array.from(trimmed).slice(0, 2).join("").toUpperCase();
+}
+
+export default async function BookmarksPage() {
+  const session = await requireAuth();
+  const { courses, lessons } = await getUserBookmarks(session.userId);
+
+  const total = courses.length + lessons.length;
+
+  return (
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
+      <header className="mb-7">
+        <div className="inline-flex items-center gap-2">
+          <Star className="size-4" aria-hidden="true" style={{ color: "var(--accent-solid)" }} />
+          <h1 className="m-0 font-bold text-[26px] tracking-tight">お気に入り</h1>
+        </div>
+        <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
+          コースとレッスンの Star を集めた一覧
+        </p>
+      </header>
+
+      {total === 0 ? (
+        <div
+          className="rounded-[14px] px-8 py-14 text-center text-[13px]"
+          style={{
+            background: "var(--bg-1)",
+            border: "1px dashed var(--line-3)",
+            color: "var(--text-3)",
+          }}
+        >
+          まだお気に入りはありません。
+          <Link
+            href="/explore"
+            className="ml-1 text-[13px]"
+            style={{ color: "var(--accent-solid)" }}
+          >
+            コースを探す →
+          </Link>
+        </div>
+      ) : null}
+
+      {courses.length > 0 ? (
+        <section className="mb-9">
+          <div className="mb-4 flex items-baseline justify-between">
+            <div>
+              <h2 className="m-0 font-semibold text-[18px] tracking-tight">コース</h2>
+              <span className="text-xs" style={{ color: "var(--text-3)" }}>
+                {courses.length} 件
+              </span>
+            </div>
+          </div>
+          <ul
+            className="grid gap-4"
+            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
+          >
+            {courses.map((b, idx) => (
+              <li key={b.id}>
+                <CourseBookmarkCard
+                  slug={b.course.slug}
+                  title={b.course.title}
+                  description={b.course.description}
+                  index={idx}
+                />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {lessons.length > 0 ? (
+        <section>
+          <div className="mb-4 flex items-baseline justify-between">
+            <div>
+              <h2 className="m-0 font-semibold text-[18px] tracking-tight">レッスン</h2>
+              <span className="text-xs" style={{ color: "var(--text-3)" }}>
+                {lessons.length} 件
+              </span>
+            </div>
+          </div>
+          <ul className="flex flex-col gap-2.5">
+            {lessons.map((b) => (
+              <li key={b.id}>
+                <LessonBookmarkRow
+                  courseSlug={b.lesson.course.slug}
+                  courseTitle={b.lesson.course.title}
+                  lessonSlug={b.lesson.slug}
+                  lessonTitle={b.lesson.title}
+                />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function CourseBookmarkCard({
+  slug,
+  title,
+  description,
+  index,
+}: {
+  slug: string;
+  title: string;
+  description: string;
+  index: number;
+}) {
+  return (
+    <Link
+      href={`/courses/${slug}`}
+      className={cn(
+        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
+        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
+      )}
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <div className={cn("cm-cover", coverFor(index))}>
+        <span className="cm-cover-glyph" aria-hidden="true">
+          {glyphFor(title)}
+        </span>
+      </div>
+      <div className="flex flex-1 flex-col gap-2 p-4">
+        <h3
+          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
+          style={{ color: "var(--text-1)" }}
+        >
+          {title}
+        </h3>
+        {description ? (
+          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
+            {description}
+          </p>
+        ) : null}
+      </div>
+    </Link>
+  );
+}
+
+function LessonBookmarkRow({
+  courseSlug,
+  courseTitle,
+  lessonSlug,
+  lessonTitle,
+}: {
+  courseSlug: string;
+  courseTitle: string;
+  lessonSlug: string;
+  lessonTitle: string;
+}) {
+  return (
+    <Link
+      href={`/courses/${courseSlug}/lessons/${lessonSlug}`}
+      className="flex items-center gap-3 rounded-[12px] px-4 py-3 transition hover:bg-[var(--bg-2)]"
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <BookText className="size-3.5" aria-hidden="true" style={{ color: "var(--text-3)" }} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium text-[14px]" style={{ color: "var(--text-1)" }}>
+          {lessonTitle}
+        </div>
+        <div className="mt-0.5 truncate text-[12px]" style={{ color: "var(--text-3)" }}>
+          {courseTitle}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
+++ b/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/_components/LessonClient.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { BookmarkButton } from "@/components/BookmarkButton";
 import { cn } from "@/lib/utils";
 import { useLessonRunner } from "../_hooks/useLessonRunner";
 
@@ -40,6 +41,7 @@ type Props = {
   prevSlug: string | null;
   nextSlug: string | null;
   initiallyCompleted: boolean;
+  initiallyBookmarked: boolean;
 };
 
 export default function LessonClient({
@@ -49,6 +51,7 @@ export default function LessonClient({
   prevSlug,
   nextSlug,
   initiallyCompleted,
+  initiallyBookmarked,
 }: Props) {
   const { code, setCode, output, running, completed, run, reset } = useLessonRunner({
     lessonId: lesson.id,
@@ -179,6 +182,12 @@ export default function LessonClient({
               <Check className="size-3" aria-hidden="true" /> クリア済み
             </span>
           ) : null}
+          <BookmarkButton
+            target="lesson"
+            lessonId={lesson.id}
+            bookmarked={initiallyBookmarked}
+            variant="compact"
+          />
         </div>
       </header>
 

--- a/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(protected)/courses/[slug]/lessons/[lessonSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { requireAuth } from "@/lib/auth";
 import { NotFoundError } from "@/lib/errors";
+import { isLessonBookmarked } from "@/services/bookmarkService";
 import { getCourseBySlug } from "@/services/courseService";
 import { isLessonCompleted } from "@/services/progressService";
 import LessonClient from "./_components/LessonClient";
@@ -28,7 +29,10 @@ export default async function LessonPage({
   const prev = idx > 0 ? course.lessons[idx - 1] : null;
   const next = idx < course.lessons.length - 1 ? course.lessons[idx + 1] : null;
 
-  const completed = await isLessonCompleted(session.userId, lesson.id);
+  const [completed, bookmarked] = await Promise.all([
+    isLessonCompleted(session.userId, lesson.id),
+    isLessonBookmarked({ userId: session.userId, lessonId: lesson.id }),
+  ]);
 
   return (
     <LessonClient
@@ -45,6 +49,7 @@ export default async function LessonPage({
       prevSlug={prev?.slug ?? null}
       nextSlug={next?.slug ?? null}
       initiallyCompleted={completed}
+      initiallyBookmarked={bookmarked}
     />
   );
 }

--- a/src/app/(protected)/courses/[slug]/page.tsx
+++ b/src/app/(protected)/courses/[slug]/page.tsx
@@ -1,9 +1,11 @@
-import { ArrowLeft, BookText, Play, Star } from "lucide-react";
+import { ArrowLeft, BookText, Play } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BookmarkButton } from "@/components/BookmarkButton";
 import { requireAuth } from "@/lib/auth";
 import { NotFoundError } from "@/lib/errors";
 import { cn } from "@/lib/utils";
+import { isCourseBookmarked } from "@/services/bookmarkService";
 import { getCourseBySlug } from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
 
@@ -27,10 +29,13 @@ export default async function CoursePage({ params }: PageProps<"/courses/[slug]"
     throw error;
   }
 
-  const completed = await getCompletedLessonIdsByUser(
-    session.userId,
-    course.lessons.map((l) => l.id),
-  );
+  const [completed, bookmarked] = await Promise.all([
+    getCompletedLessonIdsByUser(
+      session.userId,
+      course.lessons.map((l) => l.id),
+    ),
+    isCourseBookmarked({ userId: session.userId, courseId: course.id }),
+  ]);
   const completedIds = new Set(completed);
   const done = course.lessons.filter((l) => completedIds.has(l.id)).length;
   const total = course.lessons.length;
@@ -84,19 +89,7 @@ export default async function CoursePage({ params }: PageProps<"/courses/[slug]"
                 {done > 0 && done < total ? "続きから学ぶ" : "最初から始める"}
               </Link>
             ) : null}
-            <button
-              type="button"
-              disabled
-              aria-label="お気に入り (近日公開)"
-              className="inline-flex cursor-not-allowed items-center gap-2 rounded-[10px] px-4 py-2 text-[13px] opacity-60"
-              style={{
-                background: "var(--bg-2)",
-                border: "1px solid var(--line-2)",
-                color: "var(--text-1)",
-              }}
-            >
-              <Star className="size-3.5" aria-hidden="true" /> お気に入り
-            </button>
+            <BookmarkButton target="course" courseId={course.id} bookmarked={bookmarked} />
           </div>
         </div>
 

--- a/src/app/(protected)/me/page.tsx
+++ b/src/app/(protected)/me/page.tsx
@@ -1,6 +1,7 @@
-import { CheckCircle2, LogOut, Sparkles } from "lucide-react";
+import { CheckCircle2, LogOut, Sparkles, Star } from "lucide-react";
 import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
+import { getUserBookmarks } from "@/services/bookmarkService";
 import { getCoursesWithLessons, getMyCourses } from "@/services/courseService";
 import { getCompletedLessonIdsByUser } from "@/services/progressService";
 
@@ -12,16 +13,18 @@ export default async function MePage() {
   const handle = session.email ? session.email.split("@")[0] : session.userId;
   const initial = (displayName.trim()[0] ?? "?").toUpperCase();
 
-  const [myCourses, allCourses, completedIds] = await Promise.all([
+  const [myCourses, allCourses, completedIds, bookmarks] = await Promise.all([
     getMyCourses(session.userId),
     getCoursesWithLessons(),
     getCompletedLessonIdsByUser(session.userId),
+    getUserBookmarks(session.userId),
   ]);
 
   const acCount = completedIds.length;
   const totalLessonsAvailable = allCourses.reduce((acc, c) => acc + c.lessons.length, 0);
   const createdCount = myCourses.length;
   const publishedCount = myCourses.filter((c) => c.isPublished).length;
+  const bookmarkCount = bookmarks.courses.length + bookmarks.lessons.length;
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
@@ -99,6 +102,28 @@ export default async function MePage() {
           value={String(createdCount)}
           sub={`${publishedCount} 公開中`}
         />
+        <Link
+          href="/bookmarks"
+          className="rounded-[14px] p-4 transition hover:-translate-y-0.5 hover:border-[color:var(--line-3)]"
+          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+        >
+          <div
+            className="mb-1.5 inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.08em]"
+            style={{ color: "var(--text-4)", fontWeight: 600 }}
+          >
+            <Star className="size-3.5" aria-hidden="true" />
+            お気に入り
+          </div>
+          <div
+            className="font-semibold text-[28px] tracking-tight"
+            style={{ fontFamily: "var(--font-mono-family)" }}
+          >
+            {bookmarkCount}
+          </div>
+          <div className="mt-1 font-mono text-[11.5px]" style={{ color: "var(--text-3)" }}>
+            一覧を見る →
+          </div>
+        </Link>
       </div>
 
       {/* Learning heatmap (placeholder) */}

--- a/src/components/BookmarkButton.tsx
+++ b/src/components/BookmarkButton.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Star } from "lucide-react";
+import { useTransition } from "react";
+import { toggleCourseBookmarkAction, toggleLessonBookmarkAction } from "@/actions/bookmarks";
+import { cn } from "@/lib/utils";
+
+type Props = ({ target: "course"; courseId: string } | { target: "lesson"; lessonId: string }) & {
+  bookmarked: boolean;
+  variant?: "default" | "compact";
+};
+
+export function BookmarkButton(props: Props) {
+  const { bookmarked, variant = "default" } = props;
+  const [isPending, startTransition] = useTransition();
+
+  const onClick = () => {
+    startTransition(async () => {
+      if (props.target === "course") {
+        await toggleCourseBookmarkAction({ courseId: props.courseId });
+      } else {
+        await toggleLessonBookmarkAction({ lessonId: props.lessonId });
+      }
+    });
+  };
+
+  const label = bookmarked ? "お気に入り解除" : "お気に入りに追加";
+
+  if (variant === "compact") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={isPending}
+        aria-pressed={bookmarked}
+        aria-label={label}
+        title={label}
+        className={cn(
+          "inline-flex size-9 items-center justify-center rounded-[10px] transition",
+          isPending && "opacity-60",
+        )}
+        style={{
+          background: "var(--bg-2)",
+          border: "1px solid var(--line-2)",
+          color: bookmarked ? "var(--accent-solid)" : "var(--text-2)",
+        }}
+      >
+        <Star className="size-4" aria-hidden="true" fill={bookmarked ? "currentColor" : "none"} />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isPending}
+      aria-pressed={bookmarked}
+      aria-label={label}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-[10px] px-4 py-2 text-[13px] transition",
+        isPending && "opacity-60",
+      )}
+      style={{
+        background: "var(--bg-2)",
+        border: "1px solid var(--line-2)",
+        color: bookmarked ? "var(--accent-solid)" : "var(--text-1)",
+      }}
+    >
+      <Star className="size-3.5" aria-hidden="true" fill={bookmarked ? "currentColor" : "none"} />
+      {bookmarked ? "お気に入り済み" : "お気に入り"}
+    </button>
+  );
+}

--- a/src/repositories/bookmark.repository.ts
+++ b/src/repositories/bookmark.repository.ts
@@ -1,0 +1,79 @@
+import "server-only";
+
+import type { Bookmark, Course, Lesson } from "@prisma/client";
+import { BaseRepository } from "./base.repository";
+
+export type CourseBookmarkWithCourse = Bookmark & {
+  course: Course;
+};
+
+export type LessonBookmarkWithLesson = Bookmark & {
+  lesson: Lesson & { course: Pick<Course, "id" | "slug" | "title"> };
+};
+
+export class BookmarkRepository extends BaseRepository {
+  async findByUserId(userId: string): Promise<Bookmark[]> {
+    return this.client.bookmark.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async findCourseBookmarksByUser(userId: string): Promise<CourseBookmarkWithCourse[]> {
+    const rows = await this.client.bookmark.findMany({
+      where: { userId, courseId: { not: null } },
+      orderBy: { createdAt: "desc" },
+      include: { course: true },
+    });
+    return rows.filter((r): r is CourseBookmarkWithCourse => r.course !== null);
+  }
+
+  async findLessonBookmarksByUser(userId: string): Promise<LessonBookmarkWithLesson[]> {
+    const rows = await this.client.bookmark.findMany({
+      where: { userId, lessonId: { not: null } },
+      orderBy: { createdAt: "desc" },
+      include: {
+        lesson: {
+          include: { course: { select: { id: true, slug: true, title: true } } },
+        },
+      },
+    });
+    return rows.filter((r): r is LessonBookmarkWithLesson => r.lesson !== null);
+  }
+
+  async findCourseBookmark(userId: string, courseId: string): Promise<Bookmark | null> {
+    return this.client.bookmark.findUnique({
+      where: { user_course_bookmark: { userId, courseId } },
+    });
+  }
+
+  async findLessonBookmark(userId: string, lessonId: string): Promise<Bookmark | null> {
+    return this.client.bookmark.findUnique({
+      where: { user_lesson_bookmark: { userId, lessonId } },
+    });
+  }
+
+  async createCourseBookmark(userId: string, courseId: string): Promise<Bookmark> {
+    return this.client.bookmark.create({
+      data: { userId, courseId },
+    });
+  }
+
+  async deleteCourseBookmark(userId: string, courseId: string): Promise<void> {
+    await this.client.bookmark.delete({
+      where: { user_course_bookmark: { userId, courseId } },
+    });
+  }
+
+  async createLessonBookmark(userId: string, lessonId: string): Promise<Bookmark> {
+    return this.client.bookmark.create({
+      data: { userId, lessonId },
+    });
+  }
+
+  async deleteLessonBookmark(userId: string, lessonId: string): Promise<void> {
+    await this.client.bookmark.delete({
+      where: { user_lesson_bookmark: { userId, lessonId } },
+    });
+  }
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { BookmarkRepository } from "./bookmark.repository";
 import { CourseRepository } from "./course.repository";
 import { LessonRepository } from "./lesson.repository";
 import { NotificationRepository } from "./notification.repository";
@@ -7,6 +8,7 @@ import { ProfileRepository } from "./profile.repository";
 import { ProgressRepository } from "./progress.repository";
 import { SearchRepository } from "./search.repository";
 
+export const bookmarkRepository = new BookmarkRepository();
 export const courseRepository = new CourseRepository();
 export const lessonRepository = new LessonRepository();
 export const notificationRepository = new NotificationRepository();
@@ -14,6 +16,10 @@ export const profileRepository = new ProfileRepository();
 export const progressRepository = new ProgressRepository();
 export const searchRepository = new SearchRepository();
 
+export type {
+  CourseBookmarkWithCourse,
+  LessonBookmarkWithLesson,
+} from "./bookmark.repository";
 export type {
   CourseAuthor,
   CourseWithLessonIds,
@@ -26,6 +32,7 @@ export type { CreateLessonInput, UpdateLessonInput } from "./lesson.repository";
 export type { CreateNotificationInput } from "./notification.repository";
 export type { CourseSearchHit, LessonSearchHit } from "./search.repository";
 export {
+  BookmarkRepository,
   CourseRepository,
   LessonRepository,
   NotificationRepository,

--- a/src/services/bookmarkService.ts
+++ b/src/services/bookmarkService.ts
@@ -1,0 +1,125 @@
+import "server-only";
+
+import { handleUnknownError } from "@/lib/errors";
+import { logError, logInfo } from "@/lib/logging";
+import {
+  type BookmarkRepository,
+  bookmarkRepository,
+  type CourseBookmarkWithCourse,
+  type LessonBookmarkWithLesson,
+} from "@/repositories";
+
+export async function toggleCourseBookmark(
+  params: { userId: string; courseId: string },
+  repository: BookmarkRepository = bookmarkRepository,
+): Promise<{ bookmarked: boolean }> {
+  const { userId, courseId } = params;
+  logInfo("bookmarkService.toggleCourseBookmark.start", { userId, courseId });
+  try {
+    const existing = await repository.findCourseBookmark(userId, courseId);
+    if (existing) {
+      await repository.deleteCourseBookmark(userId, courseId);
+      logInfo("bookmarkService.toggleCourseBookmark.success", {
+        userId,
+        courseId,
+        bookmarked: false,
+      });
+      return { bookmarked: false };
+    }
+    await repository.createCourseBookmark(userId, courseId);
+    logInfo("bookmarkService.toggleCourseBookmark.success", {
+      userId,
+      courseId,
+      bookmarked: true,
+    });
+    return { bookmarked: true };
+  } catch (error) {
+    logError("bookmarkService.toggleCourseBookmark.error", { userId, courseId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function toggleLessonBookmark(
+  params: { userId: string; lessonId: string },
+  repository: BookmarkRepository = bookmarkRepository,
+): Promise<{ bookmarked: boolean }> {
+  const { userId, lessonId } = params;
+  logInfo("bookmarkService.toggleLessonBookmark.start", { userId, lessonId });
+  try {
+    const existing = await repository.findLessonBookmark(userId, lessonId);
+    if (existing) {
+      await repository.deleteLessonBookmark(userId, lessonId);
+      logInfo("bookmarkService.toggleLessonBookmark.success", {
+        userId,
+        lessonId,
+        bookmarked: false,
+      });
+      return { bookmarked: false };
+    }
+    await repository.createLessonBookmark(userId, lessonId);
+    logInfo("bookmarkService.toggleLessonBookmark.success", {
+      userId,
+      lessonId,
+      bookmarked: true,
+    });
+    return { bookmarked: true };
+  } catch (error) {
+    logError("bookmarkService.toggleLessonBookmark.error", { userId, lessonId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function isCourseBookmarked(
+  params: { userId: string; courseId: string },
+  repository: BookmarkRepository = bookmarkRepository,
+): Promise<boolean> {
+  const { userId, courseId } = params;
+  try {
+    const existing = await repository.findCourseBookmark(userId, courseId);
+    return existing !== null;
+  } catch (error) {
+    logError("bookmarkService.isCourseBookmarked.error", { userId, courseId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export async function isLessonBookmarked(
+  params: { userId: string; lessonId: string },
+  repository: BookmarkRepository = bookmarkRepository,
+): Promise<boolean> {
+  const { userId, lessonId } = params;
+  try {
+    const existing = await repository.findLessonBookmark(userId, lessonId);
+    return existing !== null;
+  } catch (error) {
+    logError("bookmarkService.isLessonBookmarked.error", { userId, lessonId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+export type UserBookmarks = {
+  courses: CourseBookmarkWithCourse[];
+  lessons: LessonBookmarkWithLesson[];
+};
+
+export async function getUserBookmarks(
+  userId: string,
+  repository: BookmarkRepository = bookmarkRepository,
+): Promise<UserBookmarks> {
+  logInfo("bookmarkService.getUserBookmarks.start", { userId });
+  try {
+    const [courses, lessons] = await Promise.all([
+      repository.findCourseBookmarksByUser(userId),
+      repository.findLessonBookmarksByUser(userId),
+    ]);
+    logInfo("bookmarkService.getUserBookmarks.success", {
+      userId,
+      courseCount: courses.length,
+      lessonCount: lessons.length,
+    });
+    return { courses, lessons };
+  } catch (error) {
+    logError("bookmarkService.getUserBookmarks.error", { userId }, error);
+    throw handleUnknownError(error);
+  }
+}


### PR DESCRIPTION
## Summary
- Bookmark モデル (course xor lesson の polymorphic target) と migration を追加
- Repository / Service / Server Action を実装し、再利用可能な `BookmarkButton` クライアントコンポーネントを切り出し
- Course ページの placeholder お気に入りボタンを活性化、Lesson ヘッダーに compact variant を追加
- `/bookmarks` 一覧ページと `/me` のエントリーカードを新設

## DB
- `bookmarks` テーブル: `(user_id, course_id)` / `(user_id, lesson_id)` の複合 unique と `user_id` の index、`course_id`/`lesson_id` の XOR を保証する CHECK 制約
- Prisma が CHECK 制約を直接表現できないため migration SQL を手動で記述

## Test plan
- [ ] Course ページの Star ボタンで toggle → revalidate される
- [ ] Lesson ページの compact ボタンで toggle が反映される
- [ ] `/bookmarks` でコース / レッスンが両セクションに分かれて表示される
- [ ] `/me` のお気に入りカウントが現状を反映する
- [ ] 同 user + 同 target で 2 重作成されないこと (unique 制約)
- [ ] `course_id` と `lesson_id` を両方埋めると CHECK 違反になること

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)