### PR TITLE
feat(profile): プロフィール編集機能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.4.1",
+        "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
@@ -27,6 +28,7 @@
         "prisma": "^7.7.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-hook-form": "^7.73.1",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.4.0",
@@ -1362,6 +1364,18 @@
         "hono": "^4"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "license": "MIT",
@@ -2565,6 +2579,12 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -7724,6 +7744,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.73.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.73.1.tgz",
+      "integrity": "sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-markdown": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
@@ -46,6 +47,7 @@
     "prisma": "^7.7.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-hook-form": "^7.73.1",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.4.0",

--- a/prisma/migrations/20260426000000_add_profile_username/migration.sql
+++ b/prisma/migrations/20260426000000_add_profile_username/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "profiles" ADD COLUMN     "bio" TEXT,
+ADD COLUMN     "username" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "profiles_username_key" ON "profiles"("username");
+
+-- CreateIndex
+CREATE INDEX "profiles_username_idx" ON "profiles"("username");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,8 @@ model Profile {
   id            String         @id @db.Uuid
   email         String?
   name          String?
+  username      String?        @unique
+  bio           String?
   avatarUrl     String?        @map("avatar_url")
   createdAt     DateTime       @default(now()) @map("created_at")
   updatedAt     DateTime       @updatedAt      @map("updated_at")
@@ -75,6 +77,7 @@ model Profile {
   notifications Notification[]
   bookmarks     Bookmark[]
 
+  @@index([username])
   @@map("profiles")
 }
 

--- a/src/actions/profile.ts
+++ b/src/actions/profile.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { actionClient } from "@/lib/safe-action";
+import { updateProfile } from "@/services/profileService";
+import { UpdateProfileSchema } from "@/types/profile";
+
+export const updateProfileAction = actionClient
+  .inputSchema(UpdateProfileSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const profile = await updateProfile(ctx.userId, parsedInput);
+    revalidatePath("/me", "layout");
+    revalidatePath("/me/edit");
+    return {
+      id: profile.id,
+      name: profile.name,
+      username: profile.username,
+    };
+  });

--- a/src/app/(protected)/me/edit/_components/ProfileEditForm.tsx
+++ b/src/app/(protected)/me/edit/_components/ProfileEditForm.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { type Resolver, useForm } from "react-hook-form";
+import { updateProfileAction } from "@/actions/profile";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { UpdateProfileSchema } from "@/types/profile";
+
+type FormValues = {
+  name: string;
+  username: string;
+  bio: string;
+  avatarUrl: string;
+};
+
+type Props = {
+  initial: FormValues;
+};
+
+export function ProfileEditForm({ initial }: Props) {
+  const router = useRouter();
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(UpdateProfileSchema) as Resolver<FormValues>,
+    defaultValues: initial,
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    setFormError(null);
+    const result = await updateProfileAction(values);
+
+    if (result?.serverError) {
+      setFormError(result.serverError);
+      return;
+    }
+    if (result?.validationErrors) {
+      setFormError("入力内容に誤りがあります");
+      return;
+    }
+
+    router.push("/me");
+    router.refresh();
+  });
+
+  return (
+    <form className="space-y-5" onSubmit={onSubmit} noValidate>
+      <div className="space-y-1.5">
+        <Label htmlFor="profile-name">表示名</Label>
+        <Input
+          id="profile-name"
+          {...register("name")}
+          aria-invalid={!!errors.name}
+          autoComplete="name"
+        />
+        {errors.name && (
+          <p className="text-xs text-destructive" role="alert">
+            {errors.name.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="profile-username">ユーザー名</Label>
+        <Input
+          id="profile-username"
+          {...register("username")}
+          placeholder="例: chii81020"
+          aria-invalid={!!errors.username}
+          autoComplete="username"
+        />
+        <p className="text-xs text-muted-foreground">
+          英数字 / アンダースコア / ハイフン、2〜30 文字。空欄で未設定。
+        </p>
+        {errors.username && (
+          <p className="text-xs text-destructive" role="alert">
+            {errors.username.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="profile-bio">自己紹介</Label>
+        <Textarea
+          id="profile-bio"
+          rows={4}
+          {...register("bio")}
+          placeholder="200 文字まで"
+          aria-invalid={!!errors.bio}
+        />
+        {errors.bio && (
+          <p className="text-xs text-destructive" role="alert">
+            {errors.bio.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="profile-avatar-url">アバター画像 URL</Label>
+        {/* TODO: Replace with Supabase Storage upload (separate issue). */}
+        <Input
+          id="profile-avatar-url"
+          type="url"
+          {...register("avatarUrl")}
+          placeholder="https://example.com/avatar.png"
+          aria-invalid={!!errors.avatarUrl}
+        />
+        <p className="text-xs text-muted-foreground">
+          現状は URL 直接入力のみ。アップロード機能は今後追加予定です。
+        </p>
+        {errors.avatarUrl && (
+          <p className="text-xs text-destructive" role="alert">
+            {errors.avatarUrl.message}
+          </p>
+        )}
+      </div>
+
+      {formError && (
+        <p className="text-sm text-destructive" role="alert">
+          {formError}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          disabled={isSubmitting}
+          onClick={() => router.push("/me")}
+          type="button"
+          variant="outline"
+        >
+          キャンセル
+        </Button>
+        <Button disabled={isSubmitting} type="submit">
+          {isSubmitting ? (
+            <>
+              <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+              保存中...
+            </>
+          ) : (
+            "保存"
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(protected)/me/edit/page.tsx
+++ b/src/app/(protected)/me/edit/page.tsx
@@ -1,0 +1,47 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { requireAuth } from "@/lib/auth";
+import { ProfileEditForm } from "./_components/ProfileEditForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProfileEditPage() {
+  const session = await requireAuth();
+  const { profile } = session;
+
+  return (
+    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "720px" }}>
+      <div className="mb-6">
+        <Link
+          href="/me"
+          className="inline-flex items-center gap-1.5 text-[13px]"
+          style={{ color: "var(--text-3)" }}
+        >
+          <ArrowLeft className="size-3.5" aria-hidden="true" />
+          プロフィールに戻る
+        </Link>
+      </div>
+
+      <header className="mb-7">
+        <h1 className="m-0 font-bold text-[24px] tracking-tight">プロフィール編集</h1>
+        <p className="mt-1 text-[13px]" style={{ color: "var(--text-3)" }}>
+          表示名・ユーザー名・自己紹介・アバター画像 URL を編集できます。
+        </p>
+      </header>
+
+      <section
+        className="rounded-[16px] p-6"
+        style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+      >
+        <ProfileEditForm
+          initial={{
+            name: profile.name ?? "",
+            username: profile.username ?? "",
+            bio: profile.bio ?? "",
+            avatarUrl: profile.avatarUrl ?? "",
+          }}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/app/(protected)/me/page.tsx
+++ b/src/app/(protected)/me/page.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, LogOut, Sparkles, Star } from "lucide-react";
+import { CheckCircle2, LogOut, Pencil, Sparkles, Star } from "lucide-react";
 import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 import { getUserBookmarks } from "@/services/bookmarkService";
@@ -10,7 +10,8 @@ export const dynamic = "force-dynamic";
 export default async function MePage() {
   const session = await requireAuth();
   const displayName = session.profile.name ?? session.email ?? session.userId;
-  const handle = session.email ? session.email.split("@")[0] : session.userId;
+  const handle =
+    session.profile.username ?? (session.email ? session.email.split("@")[0] : session.userId);
   const initial = (displayName.trim()[0] ?? "?").toUpperCase();
 
   const [myCourses, allCourses, completedIds, bookmarks] = await Promise.all([
@@ -68,10 +69,18 @@ export default async function MePage() {
                 {session.email}
               </div>
             ) : null}
+            {session.profile.bio ? (
+              <p
+                className="mt-2 max-w-prose whitespace-pre-wrap text-[13px] leading-relaxed"
+                style={{ color: "var(--text-2)" }}
+              >
+                {session.profile.bio}
+              </p>
+            ) : null}
           </div>
-          <form action="/auth/signout" method="post">
-            <button
-              type="submit"
+          <div className="flex items-center gap-2">
+            <Link
+              href="/me/edit"
               className="inline-flex items-center gap-1.5 rounded-[10px] px-3 py-2 text-[13px] transition hover:bg-[var(--bg-3)]"
               style={{
                 background: "var(--bg-2)",
@@ -79,9 +88,22 @@ export default async function MePage() {
                 color: "var(--text-1)",
               }}
             >
-              <LogOut className="size-3.5" aria-hidden="true" /> サインアウト
-            </button>
-          </form>
+              <Pencil className="size-3.5" aria-hidden="true" /> プロフィールを編集
+            </Link>
+            <form action="/auth/signout" method="post">
+              <button
+                type="submit"
+                className="inline-flex items-center gap-1.5 rounded-[10px] px-3 py-2 text-[13px] transition hover:bg-[var(--bg-3)]"
+                style={{
+                  background: "var(--bg-2)",
+                  border: "1px solid var(--line-2)",
+                  color: "var(--text-1)",
+                }}
+              >
+                <LogOut className="size-3.5" aria-hidden="true" /> サインアウト
+              </button>
+            </form>
+          </div>
         </div>
       </section>
 

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -30,6 +30,7 @@ export type {
 } from "./course.repository";
 export type { CreateLessonInput, UpdateLessonInput } from "./lesson.repository";
 export type { CreateNotificationInput } from "./notification.repository";
+export type { ProfileUpdateInput, ProfileUpsertInput } from "./profile.repository";
 export type { CourseSearchHit, LessonSearchHit } from "./search.repository";
 export {
   BookmarkRepository,

--- a/src/repositories/profile.repository.ts
+++ b/src/repositories/profile.repository.ts
@@ -10,9 +10,20 @@ export type ProfileUpsertInput = {
   avatarUrl?: string | null;
 };
 
+export type ProfileUpdateInput = {
+  name?: string | null;
+  username?: string | null;
+  bio?: string | null;
+  avatarUrl?: string | null;
+};
+
 export class ProfileRepository extends BaseRepository {
   async findById(id: string): Promise<Profile | null> {
     return this.client.profile.findUnique({ where: { id } });
+  }
+
+  async findByUsername(username: string): Promise<Profile | null> {
+    return this.client.profile.findUnique({ where: { username } });
   }
 
   async upsert(input: ProfileUpsertInput): Promise<Profile> {
@@ -29,6 +40,13 @@ export class ProfileRepository extends BaseRepository {
         name: input.name ?? null,
         avatarUrl: input.avatarUrl ?? null,
       },
+    });
+  }
+
+  async update(id: string, input: ProfileUpdateInput): Promise<Profile> {
+    return this.client.profile.update({
+      where: { id },
+      data: input,
     });
   }
 }

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import type { Profile } from "@prisma/client";
+import { handleUnknownError, ValidationError } from "@/lib/errors";
+import { logError, logInfo } from "@/lib/logging";
+import { type ProfileRepository, type ProfileUpdateInput, profileRepository } from "@/repositories";
+
+export async function updateProfile(
+  userId: string,
+  data: ProfileUpdateInput,
+  repository: ProfileRepository = profileRepository,
+): Promise<Profile> {
+  logInfo("profileService.updateProfile.start", { userId });
+  try {
+    const updated = await repository.update(userId, data);
+    logInfo("profileService.updateProfile.success", { userId });
+    return updated;
+  } catch (error) {
+    if (isUniqueConstraintError(error, "username")) {
+      logInfo("profileService.updateProfile.duplicateUsername", { userId });
+      throw new ValidationError("このユーザー名は既に使われています");
+    }
+    logError("profileService.updateProfile.error", { userId }, error);
+    throw handleUnknownError(error);
+  }
+}
+
+function isUniqueConstraintError(error: unknown, field?: string): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as { code?: unknown; meta?: { target?: unknown } };
+  if (e.code !== "P2002") return false;
+  if (!field) return true;
+  const target = e.meta?.target;
+  if (Array.isArray(target)) return target.includes(field);
+  if (typeof target === "string") return target.includes(field);
+  return false;
+}

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+const USERNAME_REGEX = /^[a-z0-9_-]+$/i;
+
+// Empty strings from the edit form mean "clear this optional field". Normalise
+// them to null up-front so the rest of the schema can stay tight.
+const optionalText = <S extends z.ZodTypeAny>(schema: S) =>
+  z.preprocess((v) => (typeof v === "string" && v.trim() === "" ? null : v), schema.nullable());
+
+export const UpdateProfileSchema = z.object({
+  name: z.string().trim().min(1, "名前を入力してください").max(50, "50 文字以内で入力してください"),
+  username: optionalText(
+    z
+      .string()
+      .trim()
+      .min(2, "2 文字以上で入力してください")
+      .max(30, "30 文字以内で入力してください")
+      .regex(USERNAME_REGEX, "英数字、_、- のみ使用できます"),
+  ),
+  bio: optionalText(z.string().trim().max(200, "200 文字以内で入力してください")),
+  avatarUrl: optionalText(
+    z
+      .string()
+      .trim()
+      .max(500, "URL が長すぎます")
+      .url("正しい URL を入力してください")
+      .startsWith("https://", "https:// 始まりの URL を入力してください"),
+  ),
+});
+
+export type UpdateProfileInput = z.infer<typeof UpdateProfileSchema>;


### PR DESCRIPTION
## Summary

- `Profile` モデルに `username` (unique) / `bio` 列を追加
- `/me/edit` ページを新設し、表示名 / ユーザー名 / 自己紹介 / アバター URL を編集可能に
- `updateProfileAction` (next-safe-action + zod) を Server Action として追加し、`username` の重複は `ValidationError` に写像
- `/me` ヒーローに「プロフィールを編集」リンクと bio 表示を追加

## Stack / 規約

- Repository → Service → Server Action → UI のレイヤー分離
- フォームは React Hook Form + `@hookform/resolvers/zod` (本 PR で初導入)
- shadcn `Input` / `Textarea` / `Label` / `Button` をベースに構成

## Migration

- `prisma/migrations/20260426000000_add_profile_username/migration.sql` を新規追加
- 既存ユーザーは `username` / `bio` ともに NULL のまま (移行期は nullable)
- Supabase への apply はユーザー側で `prisma migrate deploy` を実行

## Out of scope

- アバター画像のアップロード (Supabase Storage 連携) は別 issue
- 他ユーザーの公開プロフィール表示は #63 で対応

## Test plan

- [ ] `/me/edit` にアクセスし、表示名・ユーザー名・自己紹介・アバター URL の保存ができること
- [ ] 重複 username で `このユーザー名は既に使われています` が表示されること
- [ ] zod 検証エラー (短すぎる username 等) がフィールド下に表示されること
- [ ] 未認証ユーザーは `/me/edit` から `/login` へリダイレクトされること

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)