### PR TITLE
refactor(profile): スキーマ刷新 (固有ID分離 / email削除 / handle reservation)

### DIFF
--- a/prisma/migrations/20260427100000_add_profile_auth_user_id_and_cuid/migration.sql
+++ b/prisma/migrations/20260427100000_add_profile_auth_user_id_and_cuid/migration.sql
@@ -1,0 +1,39 @@
+-- Step 1/7 of the Profile schema overhaul (issue #69).
+--
+-- Goal: split auth identifier off the primary key and prepare a TEXT id_new
+-- column that will become the new cuid-style PK in step 3. We do NOT touch
+-- foreign keys yet — those move to id_new in step 2 once every profile has a
+-- non-null id_new value.
+--
+-- Idempotent UPDATE: WHERE clauses guard against re-running the data fill.
+-- The id_new value is derived deterministically from the existing UUID so
+-- repeating the migration produces the same string per row.
+
+-- 1. Add the new columns as nullable so existing rows stay valid until they
+--    are backfilled.
+ALTER TABLE "profiles"
+  ADD COLUMN "auth_user_id" UUID,
+  ADD COLUMN "id_new"       TEXT;
+
+-- 2. Backfill: auth_user_id mirrors the legacy id (which today equals
+--    auth.users.id), and id_new is a deterministic 25-char value
+--    ('c' + first 24 hex chars of the UUID) that is collision-resistant at
+--    MVP scale and shaped like a cuid for downstream code.
+UPDATE "profiles"
+   SET "auth_user_id" = "id",
+       "id_new"       = 'c' || substring(replace("id"::text, '-', ''), 1, 24)
+ WHERE "auth_user_id" IS NULL OR "id_new" IS NULL;
+
+-- 3. Now that every row has values, lock them in.
+ALTER TABLE "profiles"
+  ALTER COLUMN "auth_user_id" SET NOT NULL,
+  ALTER COLUMN "id_new"       SET NOT NULL;
+
+-- 4. Indexes that match Prisma's default naming so step 7 (schema sync) does
+--    not generate spurious diffs. The plain index on auth_user_id duplicates
+--    the unique index intentionally — Prisma's @@index([authUserId]) emits
+--    both, and we want this migration to leave the DB in the exact shape
+--    the schema describes.
+CREATE UNIQUE INDEX "profiles_auth_user_id_key" ON "profiles"("auth_user_id");
+CREATE INDEX        "profiles_auth_user_id_idx" ON "profiles"("auth_user_id");
+CREATE UNIQUE INDEX "profiles_id_new_key"       ON "profiles"("id_new");

--- a/prisma/migrations/20260427100100_repoint_fks_to_profile_id_new/migration.sql
+++ b/prisma/migrations/20260427100100_repoint_fks_to_profile_id_new/migration.sql
@@ -1,0 +1,92 @@
+-- Step 2/7 of the Profile schema overhaul (issue #69).
+--
+-- Goal: every table that today references profiles.id (UUID) gets a parallel
+-- TEXT column pointing at profiles.id_new, with proper FK constraints. The
+-- legacy UUID columns are kept around (without their FK constraints) until
+-- step 4, so a half-applied migration can still be diagnosed with a SELECT.
+--
+-- Order of operations per table:
+--   1. add *_id_new TEXT (nullable)
+--   2. UPDATE … FROM profiles to populate it via the legacy id
+--   3. SET NOT NULL where the legacy column was NOT NULL
+--   4. drop the legacy FK constraint and add the new one targeting id_new
+-- Indexes on the new column are created here so the downstream rename step
+-- (step 4) only has to swap names, not rebuild btree structures.
+--
+-- Course.author_id is nullable (official courses), so we skip the NOT NULL
+-- step for it.
+
+-- ---- Course ----------------------------------------------------------------
+ALTER TABLE "Course" ADD COLUMN "author_id_new" TEXT;
+
+UPDATE "Course" c
+   SET "author_id_new" = p."id_new"
+  FROM "profiles" p
+ WHERE c."author_id" = p."id"
+   AND c."author_id_new" IS NULL;
+
+ALTER TABLE "Course" DROP CONSTRAINT "Course_author_id_fkey";
+ALTER TABLE "Course"
+  ADD CONSTRAINT "Course_author_id_new_fkey"
+  FOREIGN KEY ("author_id_new") REFERENCES "profiles"("id_new")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "Course_author_id_new_slug_key" ON "Course"("author_id_new", "slug");
+CREATE INDEX        "Course_author_id_new_idx"      ON "Course"("author_id_new");
+
+-- ---- Bookmark --------------------------------------------------------------
+ALTER TABLE "bookmarks" ADD COLUMN "user_id_new" TEXT;
+
+UPDATE "bookmarks" b
+   SET "user_id_new" = p."id_new"
+  FROM "profiles" p
+ WHERE b."user_id" = p."id"
+   AND b."user_id_new" IS NULL;
+
+ALTER TABLE "bookmarks" ALTER COLUMN "user_id_new" SET NOT NULL;
+ALTER TABLE "bookmarks" DROP CONSTRAINT "bookmarks_user_id_fkey";
+ALTER TABLE "bookmarks"
+  ADD CONSTRAINT "bookmarks_user_id_new_fkey"
+  FOREIGN KEY ("user_id_new") REFERENCES "profiles"("id_new")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "bookmarks_user_id_new_course_id_key" ON "bookmarks"("user_id_new", "course_id");
+CREATE UNIQUE INDEX "bookmarks_user_id_new_lesson_id_key" ON "bookmarks"("user_id_new", "lesson_id");
+CREATE INDEX        "bookmarks_user_id_new_idx"           ON "bookmarks"("user_id_new");
+
+-- ---- Notification ----------------------------------------------------------
+ALTER TABLE "notifications" ADD COLUMN "recipient_id_new" TEXT;
+
+UPDATE "notifications" n
+   SET "recipient_id_new" = p."id_new"
+  FROM "profiles" p
+ WHERE n."recipient_id" = p."id"
+   AND n."recipient_id_new" IS NULL;
+
+ALTER TABLE "notifications" ALTER COLUMN "recipient_id_new" SET NOT NULL;
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_recipient_id_fkey";
+ALTER TABLE "notifications"
+  ADD CONSTRAINT "notifications_recipient_id_new_fkey"
+  FOREIGN KEY ("recipient_id_new") REFERENCES "profiles"("id_new")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE INDEX "notifications_recipient_id_new_created_at_idx" ON "notifications"("recipient_id_new", "created_at");
+CREATE INDEX "notifications_recipient_id_new_read_at_idx"    ON "notifications"("recipient_id_new", "read_at");
+
+-- ---- Progress --------------------------------------------------------------
+ALTER TABLE "progress" ADD COLUMN "user_id_new" TEXT;
+
+UPDATE "progress" pr
+   SET "user_id_new" = p."id_new"
+  FROM "profiles" p
+ WHERE pr."user_id" = p."id"
+   AND pr."user_id_new" IS NULL;
+
+ALTER TABLE "progress" ALTER COLUMN "user_id_new" SET NOT NULL;
+ALTER TABLE "progress" DROP CONSTRAINT "progress_user_id_fkey";
+ALTER TABLE "progress"
+  ADD CONSTRAINT "progress_user_id_new_fkey"
+  FOREIGN KEY ("user_id_new") REFERENCES "profiles"("id_new")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "progress_user_id_new_lessonId_key" ON "progress"("user_id_new", "lessonId");

--- a/prisma/migrations/20260427100200_swap_profile_pk/migration.sql
+++ b/prisma/migrations/20260427100200_swap_profile_pk/migration.sql
@@ -1,0 +1,25 @@
+-- Step 3/7 of the Profile schema overhaul (issue #69).
+--
+-- Goal: the legacy auth-shaped profiles.id (UUID) is no longer referenced by
+-- any FK (the FKs added in step 2 point at profiles.id_new), so we can drop
+-- it and promote id_new to the primary key.
+--
+-- The unique index profiles_id_new_key created in step 1 is what the new
+-- FKs reference. We cannot drop it without taking those FKs with it, so we
+-- reuse it as the new PK via `ADD CONSTRAINT … USING INDEX`. Postgres
+-- atomically renames the index to profiles_pkey and promotes it to a
+-- PRIMARY KEY constraint, leaving the FKs intact.
+
+-- 1. Drop the legacy primary key constraint and its UUID column.
+ALTER TABLE "profiles" DROP CONSTRAINT "profiles_pkey";
+ALTER TABLE "profiles" DROP COLUMN "id";
+
+-- 2. Rename id_new -> id. The unique index profiles_id_new_key follows the
+--    column automatically (it just stores a column oid), so it is unchanged.
+ALTER TABLE "profiles" RENAME COLUMN "id_new" TO "id";
+
+-- 3. Promote the existing unique index to the primary key. The constraint
+--    name becomes the new index name, which keeps Prisma's expectations
+--    (profiles_pkey) and means we do not have to rebuild a btree.
+ALTER TABLE "profiles"
+  ADD CONSTRAINT "profiles_pkey" PRIMARY KEY USING INDEX "profiles_id_new_key";

--- a/prisma/migrations/20260427100300_swap_fk_columns/migration.sql
+++ b/prisma/migrations/20260427100300_swap_fk_columns/migration.sql
@@ -1,0 +1,38 @@
+-- Step 4/7 of the Profile schema overhaul (issue #69).
+--
+-- Goal: drop the now-unused legacy UUID FK columns on every dependent table
+-- and rename the *_id_new columns / indexes / constraints back to their
+-- canonical names. After this step the schema looks identical to the legacy
+-- one except every FK is TEXT and points at profiles(id) (the cuid).
+--
+-- Dropping the legacy column also removes any indexes Postgres still has on
+-- it, which is why we don't have to drop the legacy unique indexes
+-- explicitly — they vanish with the column.
+
+-- ---- Course ----------------------------------------------------------------
+ALTER TABLE "Course" DROP COLUMN "author_id";
+ALTER TABLE "Course" RENAME COLUMN "author_id_new" TO "author_id";
+ALTER INDEX  "Course_author_id_new_slug_key"     RENAME TO "Course_author_id_slug_key";
+ALTER INDEX  "Course_author_id_new_idx"          RENAME TO "Course_author_id_idx";
+ALTER TABLE  "Course" RENAME CONSTRAINT "Course_author_id_new_fkey" TO "Course_author_id_fkey";
+
+-- ---- Bookmark --------------------------------------------------------------
+ALTER TABLE "bookmarks" DROP COLUMN "user_id";
+ALTER TABLE "bookmarks" RENAME COLUMN "user_id_new" TO "user_id";
+ALTER INDEX  "bookmarks_user_id_new_course_id_key" RENAME TO "bookmarks_user_id_course_id_key";
+ALTER INDEX  "bookmarks_user_id_new_lesson_id_key" RENAME TO "bookmarks_user_id_lesson_id_key";
+ALTER INDEX  "bookmarks_user_id_new_idx"           RENAME TO "bookmarks_user_id_idx";
+ALTER TABLE  "bookmarks" RENAME CONSTRAINT "bookmarks_user_id_new_fkey" TO "bookmarks_user_id_fkey";
+
+-- ---- Notification ----------------------------------------------------------
+ALTER TABLE "notifications" DROP COLUMN "recipient_id";
+ALTER TABLE "notifications" RENAME COLUMN "recipient_id_new" TO "recipient_id";
+ALTER INDEX  "notifications_recipient_id_new_created_at_idx" RENAME TO "notifications_recipient_id_created_at_idx";
+ALTER INDEX  "notifications_recipient_id_new_read_at_idx"    RENAME TO "notifications_recipient_id_read_at_idx";
+ALTER TABLE  "notifications" RENAME CONSTRAINT "notifications_recipient_id_new_fkey" TO "notifications_recipient_id_fkey";
+
+-- ---- Progress --------------------------------------------------------------
+ALTER TABLE "progress" DROP COLUMN "user_id";
+ALTER TABLE "progress" RENAME COLUMN "user_id_new" TO "user_id";
+ALTER INDEX  "progress_user_id_new_lessonId_key" RENAME TO "progress_user_id_lessonId_key";
+ALTER TABLE  "progress" RENAME CONSTRAINT "progress_user_id_new_fkey" TO "progress_user_id_fkey";

--- a/prisma/migrations/20260427100400_drop_profile_email/migration.sql
+++ b/prisma/migrations/20260427100400_drop_profile_email/migration.sql
@@ -1,0 +1,9 @@
+-- Step 5/7 of the Profile schema overhaul (issue #69).
+--
+-- Goal: profiles.email duplicates auth.users.email and is never read by the
+-- application now that requireAuth pulls the email straight from Supabase.
+-- Drop it together with whatever unique index Prisma had attached.
+--
+-- Postgres auto-drops indexes when the underlying column is dropped, so a
+-- single DROP COLUMN is enough.
+ALTER TABLE "profiles" DROP COLUMN "email";

--- a/prisma/migrations/20260427100500_rename_username_to_handle/migration.sql
+++ b/prisma/migrations/20260427100500_rename_username_to_handle/migration.sql
@@ -1,0 +1,12 @@
+-- Step 6/7 of the Profile schema overhaul (issue #69).
+--
+-- Goal: profiles.username has always meant "URL handle". Rename it so the
+-- column name matches the concept; a coordinated reservation table is added
+-- in step 7 to enforce 90-day cooldowns.
+--
+-- The old schema declared both `@unique` and `@@index([username])`, which
+-- produced two btree indexes on the same column. The new schema only keeps
+-- the unique index, so we rename it and drop the redundant plain index.
+ALTER TABLE "profiles" RENAME COLUMN "username" TO "handle";
+ALTER INDEX  "profiles_username_key" RENAME TO "profiles_handle_key";
+DROP INDEX   "profiles_username_idx";

--- a/prisma/migrations/20260427100600_add_handle_reservation/migration.sql
+++ b/prisma/migrations/20260427100600_add_handle_reservation/migration.sql
@@ -1,0 +1,16 @@
+-- Step 7/7 of the Profile schema overhaul (issue #69).
+--
+-- Goal: introduce handle_reservations so that when a user renames their
+-- handle, the old value is parked for 90 days before anyone else can claim
+-- it. This closes the time-axis URL-collision discussed in the issue: a
+-- previously-shared /courses/{old-handle}/... cannot suddenly resolve to a
+-- different person.
+CREATE TABLE "handle_reservations" (
+    "handle"      TEXT          NOT NULL,
+    "released_at" TIMESTAMP(3)  NOT NULL,
+    "created_at"  TIMESTAMP(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "handle_reservations_pkey" PRIMARY KEY ("handle")
+);
+
+CREATE INDEX "handle_reservations_released_at_idx" ON "handle_reservations"("released_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,7 @@ model Course {
   title        String
   description  String
   order        Int
-  authorId     String?            @db.Uuid @map("author_id")
+  authorId     String?            @map("author_id")
   author       Profile?           @relation(fields: [authorId], references: [id], onDelete: SetNull)
   isPublished  Boolean            @default(false) @map("is_published")
   providerType CourseProviderType @default(COMMUNITY) @map("provider_type")
@@ -54,7 +54,7 @@ model Lesson {
 
 model Progress {
   id          String   @id @default(cuid())
-  userId      String   @db.Uuid @map("user_id")
+  userId      String   @map("user_id")
   lessonId    String
   user        Profile  @relation(fields: [userId], references: [id], onDelete: Cascade)
   lesson      Lesson   @relation(fields: [lessonId], references: [id], onDelete: Cascade)
@@ -65,10 +65,10 @@ model Progress {
 }
 
 model Profile {
-  id            String         @id @db.Uuid
-  email         String?
+  id            String         @id @default(cuid())
+  authUserId    String         @unique @db.Uuid @map("auth_user_id")
+  handle        String         @unique
   name          String?
-  username      String         @unique
   bio           String?
   avatarUrl     String?        @map("avatar_url")
   createdAt     DateTime       @default(now()) @map("created_at")
@@ -78,7 +78,7 @@ model Profile {
   notifications Notification[]
   bookmarks     Bookmark[]
 
-  @@index([username])
+  @@index([authUserId])
   @@map("profiles")
 }
 
@@ -91,7 +91,7 @@ enum NotificationType {
 
 model Notification {
   id          String           @id @default(cuid())
-  recipientId String           @db.Uuid @map("recipient_id")
+  recipientId String           @map("recipient_id")
   recipient   Profile          @relation(fields: [recipientId], references: [id], onDelete: Cascade)
   type        NotificationType
   title       String
@@ -107,7 +107,7 @@ model Notification {
 
 model Bookmark {
   id        String   @id @default(cuid())
-  userId    String   @db.Uuid @map("user_id")
+  userId    String   @map("user_id")
   user      Profile  @relation(fields: [userId], references: [id], onDelete: Cascade)
   courseId  String?  @map("course_id")
   course    Course?  @relation(fields: [courseId], references: [id], onDelete: Cascade)
@@ -119,4 +119,13 @@ model Bookmark {
   @@unique([userId, lessonId], name: "user_lesson_bookmark")
   @@index([userId])
   @@map("bookmarks")
+}
+
+model HandleReservation {
+  handle     String   @id
+  releasedAt DateTime @map("released_at")
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@index([releasedAt])
+  @@map("handle_reservations")
 }

--- a/prisma/sql/001_profiles_trigger.sql
+++ b/prisma/sql/001_profiles_trigger.sql
@@ -1,17 +1,23 @@
--- Sync auth.users -> public.profiles
+-- Sync auth.users -> public.profiles (issue #69 schema).
 -- Apply via: psql "$DIRECT_URL" -f prisma/sql/001_profiles_trigger.sql
 -- Or paste into the Supabase SQL Editor.
+--
+-- Profile.id is a cuid-shaped TEXT generated deterministically from the
+-- auth UUID ('c' + first 24 hex chars). Determinism keeps the seed and the
+-- trigger producing the same id for the same auth user no matter how many
+-- times the script is replayed, which makes ON CONFLICT (auth_user_id)
+-- safe to re-run.
 
-INSERT INTO public.profiles (id, email, name, username, avatar_url, created_at, updated_at)
-SELECT id,
-       email,
+INSERT INTO public.profiles (id, auth_user_id, name, handle, avatar_url, created_at, updated_at)
+SELECT 'c' || substring(replace(id::text, '-', ''), 1, 24),
+       id,
        raw_user_meta_data->>'name',
        'user_' || substring(replace(id::text, '-', ''), 1, 12),
        raw_user_meta_data->>'avatar_url',
        now(),
        now()
 FROM auth.users
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (auth_user_id) DO NOTHING;
 
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER
@@ -19,21 +25,23 @@ LANGUAGE plpgsql
 SECURITY DEFINER SET search_path = public
 AS $$
 BEGIN
-  -- username is NOT NULL; seed a deterministic placeholder so the trigger
+  -- handle is NOT NULL; seed a deterministic placeholder so the trigger
   -- never violates the constraint. Users can rename it via /me/edit.
-  INSERT INTO public.profiles (id, email, name, username, avatar_url, created_at, updated_at)
+  INSERT INTO public.profiles (id, auth_user_id, name, handle, avatar_url, created_at, updated_at)
   VALUES (
+    'c' || substring(replace(NEW.id::text, '-', ''), 1, 24),
     NEW.id,
-    NEW.email,
     NEW.raw_user_meta_data->>'name',
     'user_' || substring(replace(NEW.id::text, '-', ''), 1, 12),
     NEW.raw_user_meta_data->>'avatar_url',
     now(),
     now()
   )
-  ON CONFLICT (id) DO UPDATE
-    SET email = EXCLUDED.email,
-        name = EXCLUDED.name,
+  ON CONFLICT (auth_user_id) DO UPDATE
+    -- Keep display-name / avatar in sync when Supabase metadata changes.
+    -- Do NOT touch handle here: a user may have renamed it via /me/edit
+    -- and the OAuth payload would otherwise overwrite their choice.
+    SET name = EXCLUDED.name,
         avatar_url = EXCLUDED.avatar_url,
         updated_at = now();
   RETURN NEW;

--- a/src/actions/profile.ts
+++ b/src/actions/profile.ts
@@ -14,6 +14,6 @@ export const updateProfileAction = actionClient
     return {
       id: profile.id,
       name: profile.name,
-      username: profile.username,
+      handle: profile.handle,
     };
   });

--- a/src/app/(protected)/me/edit/_components/ProfileEditForm.tsx
+++ b/src/app/(protected)/me/edit/_components/ProfileEditForm.tsx
@@ -14,7 +14,7 @@ import { UpdateProfileSchema } from "@/types/profile";
 
 type FormValues = {
   name: string;
-  username: string;
+  handle: string;
   bio: string;
   avatarUrl: string;
 };
@@ -71,20 +71,24 @@ export function ProfileEditForm({ initial }: Props) {
       </div>
 
       <div className="space-y-1.5">
-        <Label htmlFor="profile-username">ユーザー名</Label>
+        <Label htmlFor="profile-handle">ハンドル (URL 用)</Label>
         <Input
-          id="profile-username"
-          {...register("username")}
+          id="profile-handle"
+          {...register("handle")}
           placeholder="例: chii81020"
-          aria-invalid={!!errors.username}
+          aria-invalid={!!errors.handle}
           autoComplete="username"
         />
         <p className="text-xs text-muted-foreground">
-          小文字英数字 / アンダースコア / ハイフン、2〜30 文字。コース URL に使われます。
+          小文字英数字 / アンダースコア / ハイフン、2〜30 文字。コース URL (/courses/{"{"}ハンドル
+          {"}"}) に使われます。
         </p>
-        {errors.username && (
+        <p className="text-xs text-muted-foreground">
+          変更すると 90 日間は他のユーザーが取得できなくなります。旧 URL は無効になります。
+        </p>
+        {errors.handle && (
           <p className="text-xs text-destructive" role="alert">
-            {errors.username.message}
+            {errors.handle.message}
           </p>
         )}
       </div>

--- a/src/app/(protected)/me/edit/page.tsx
+++ b/src/app/(protected)/me/edit/page.tsx
@@ -25,7 +25,7 @@ export default async function ProfileEditPage() {
       <header className="mb-7">
         <h1 className="m-0 font-bold text-[24px] tracking-tight">プロフィール編集</h1>
         <p className="mt-1 text-[13px]" style={{ color: "var(--text-3)" }}>
-          表示名・ユーザー名・自己紹介・アバター画像 URL を編集できます。
+          表示名・ハンドル・自己紹介・アバター画像 URL を編集できます。
         </p>
       </header>
 
@@ -36,7 +36,7 @@ export default async function ProfileEditPage() {
         <ProfileEditForm
           initial={{
             name: profile.name ?? "",
-            username: profile.username,
+            handle: profile.handle,
             bio: profile.bio ?? "",
             avatarUrl: profile.avatarUrl ?? "",
           }}

--- a/src/app/(protected)/me/page.tsx
+++ b/src/app/(protected)/me/page.tsx
@@ -12,7 +12,7 @@ export const dynamic = "force-dynamic";
 export default async function MePage() {
   const session = await requireAuth();
   const displayName = session.profile.name ?? session.email ?? session.userId;
-  const handle = session.profile.username;
+  const handle = session.profile.handle;
   const initial = (displayName.trim()[0] ?? "?").toUpperCase();
 
   const [myCourses, allCourses, completedIds, bookmarks] = await Promise.all([

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,25 +26,26 @@ export async function requireAuth(): Promise<Session> {
     if (error || !user) throw new UnauthorizedError("not signed in");
 
     // Happy path: the auth.users -> profiles trigger has already created the
-    // row, so a single SELECT is enough. Fall back to UPSERT only when the
-    // trigger has not run yet (first-time sign-in before the migration is
-    // applied) — avoids a write on every protected request.
-    let profile = await profileRepository.findById(user.id);
+    // row keyed by auth_user_id, so a single SELECT is enough. Fall back to
+    // UPSERT only when the trigger has not run yet (first-time sign-in before
+    // the migration is applied) — avoids a write on every protected request.
+    let profile = await profileRepository.findByAuthUserId(user.id);
     if (!profile) {
       const meta = (user.user_metadata ?? {}) as Record<string, unknown>;
       const name = typeof meta.name === "string" ? meta.name : null;
       const avatarUrl = typeof meta.avatar_url === "string" ? meta.avatar_url : null;
       profile = await profileRepository.upsert({
-        id: user.id,
-        email: user.email ?? null,
+        authUserId: user.id,
         name,
-        username: defaultUsernameFor(user.id),
+        handle: defaultHandleFor(user.id),
         avatarUrl,
       });
     }
 
     return {
-      userId: user.id,
+      // userId is the cuid Profile.id, not the auth UUID. Downstream code
+      // (services, repositories, FKs) only ever sees the application id.
+      userId: profile.id,
       email: user.email ?? null,
       role: "USER",
       profile,
@@ -55,12 +56,12 @@ export async function requireAuth(): Promise<Session> {
 }
 
 /**
- * Mirrors the SQL fallback used by the `handle_new_user` trigger and the
- * `backfill_profile_username` migration so a user landing here before the
- * trigger has populated their row gets the same handle either way.
+ * Mirrors the SQL fallback used by the `handle_new_user` trigger so a user
+ * landing here before the trigger has populated their row gets the same
+ * handle either way.
  */
-function defaultUsernameFor(userId: string): string {
-  return `user_${userId.replace(/-/g, "").slice(0, 12)}`;
+function defaultHandleFor(authUserId: string): string {
+  return `user_${authUserId.replace(/-/g, "").slice(0, 12)}`;
 }
 
 export async function requireRole(role: Role): Promise<Session> {

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -2,7 +2,7 @@
  * Centralised URL builders for Course / Lesson learner pages.
  *
  * Course pages live under `/courses/{handle}/{slug}` where:
- *   - `handle` is the author's `Profile.username` for UGC courses
+ *   - `handle` is the author's `Profile.handle` for UGC courses
  *   - `handle` is the reserved literal `OFFICIAL_HANDLE` for official courses
  *     whose `authorId` is NULL
  *
@@ -14,11 +14,11 @@ export const OFFICIAL_HANDLE = "official";
 
 export type CourseLinkable = {
   slug: string;
-  author: { username: string } | null;
+  author: { handle: string } | null;
 };
 
-export function authorHandle(author: { username: string } | null): string {
-  return author?.username ?? OFFICIAL_HANDLE;
+export function authorHandle(author: { handle: string } | null): string {
+  return author?.handle ?? OFFICIAL_HANDLE;
 }
 
 export function courseUrl(course: CourseLinkable): string {

--- a/src/repositories/bookmark.repository.ts
+++ b/src/repositories/bookmark.repository.ts
@@ -4,13 +4,13 @@ import type { Bookmark, Course, Lesson } from "@prisma/client";
 import { BaseRepository } from "./base.repository";
 
 export type CourseBookmarkWithCourse = Bookmark & {
-  course: Course & { author: { username: string } | null };
+  course: Course & { author: { handle: string } | null };
 };
 
 export type LessonBookmarkWithLesson = Bookmark & {
   lesson: Lesson & {
     course: Pick<Course, "id" | "slug" | "title"> & {
-      author: { username: string } | null;
+      author: { handle: string } | null;
     };
   };
 };
@@ -29,7 +29,7 @@ export class BookmarkRepository extends BaseRepository {
       orderBy: { createdAt: "desc" },
       include: {
         course: {
-          include: { author: { select: { username: true } } },
+          include: { author: { select: { handle: true } } },
         },
       },
     });
@@ -48,7 +48,7 @@ export class BookmarkRepository extends BaseRepository {
                 id: true,
                 slug: true,
                 title: true,
-                author: { select: { username: true } },
+                author: { select: { handle: true } },
               },
             },
           },

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -8,17 +8,15 @@ export type CourseWithLessonIds = Course & { lessons: Pick<Lesson, "id">[] };
 
 export type CourseAuthor = {
   id: string;
-  email: string | null;
   name: string | null;
-  username: string;
+  handle: string;
   avatarUrl: string | null;
 };
 
 const COURSE_AUTHOR_SELECT = {
   id: true,
-  email: true,
   name: true,
-  username: true,
+  handle: true,
   avatarUrl: true,
 } as const;
 
@@ -120,11 +118,11 @@ export class CourseRepository extends BaseRepository {
   /**
    * Resolve a course addressed by `/courses/{handle}/{slug}`.
    * - `handle === OFFICIAL_HANDLE` matches courses with `authorId IS NULL`.
-   * - Any other handle is looked up against `Profile.username`; an unknown
+   * - Any other handle is looked up against `Profile.handle`; an unknown
    *   handle returns `null` (the page should `notFound()`).
    *
    * Two queries on the UGC path is fine — both columns are indexed
-   * (`profiles.username` unique + `Course(authorId, slug)` unique).
+   * (`profiles.handle` unique + `Course(authorId, slug)` unique).
    */
   async findPublishedByHandleAndSlugWithPublishedLessons(params: {
     handle: string;
@@ -137,7 +135,7 @@ export class CourseRepository extends BaseRepository {
       authorId = null;
     } else {
       const profile = await this.client.profile.findUnique({
-        where: { username: handle },
+        where: { handle },
         select: { id: true },
       });
       if (!profile) return null;

--- a/src/repositories/handleReservation.repository.ts
+++ b/src/repositories/handleReservation.repository.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import type { HandleReservation } from "@prisma/client";
+import { BaseRepository } from "./base.repository";
+
+const RESERVATION_DAYS = 90;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export class HandleReservationRepository extends BaseRepository {
+  async findByHandle(handle: string): Promise<HandleReservation | null> {
+    return this.client.handleReservation.findUnique({ where: { handle } });
+  }
+
+  /**
+   * Park a handle for {@link RESERVATION_DAYS} days starting from `now`.
+   * Re-using the same handle resets the timer (intentional: a handle that
+   * cycles through several owners restarts the cooldown each rename).
+   */
+  async reserve(handle: string, now: Date = new Date()): Promise<HandleReservation> {
+    const releasedAt = new Date(now.getTime() + RESERVATION_DAYS * MS_PER_DAY);
+    return this.client.handleReservation.upsert({
+      where: { handle },
+      update: { releasedAt },
+      create: { handle, releasedAt },
+    });
+  }
+
+  /** Remove reservations whose cooldown has elapsed. Idempotent. */
+  async purgeExpired(now: Date = new Date()): Promise<number> {
+    const result = await this.client.handleReservation.deleteMany({
+      where: { releasedAt: { lte: now } },
+    });
+    return result.count;
+  }
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { BookmarkRepository } from "./bookmark.repository";
 import { CourseRepository } from "./course.repository";
+import { HandleReservationRepository } from "./handleReservation.repository";
 import { LessonRepository } from "./lesson.repository";
 import { NotificationRepository } from "./notification.repository";
 import { ProfileRepository } from "./profile.repository";
@@ -10,6 +11,7 @@ import { SearchRepository } from "./search.repository";
 
 export const bookmarkRepository = new BookmarkRepository();
 export const courseRepository = new CourseRepository();
+export const handleReservationRepository = new HandleReservationRepository();
 export const lessonRepository = new LessonRepository();
 export const notificationRepository = new NotificationRepository();
 export const profileRepository = new ProfileRepository();
@@ -35,6 +37,7 @@ export type { CourseSearchHit, LessonSearchHit } from "./search.repository";
 export {
   BookmarkRepository,
   CourseRepository,
+  HandleReservationRepository,
   LessonRepository,
   NotificationRepository,
   ProfileRepository,

--- a/src/repositories/profile.repository.ts
+++ b/src/repositories/profile.repository.ts
@@ -4,17 +4,16 @@ import type { Profile } from "@prisma/client";
 import { BaseRepository } from "./base.repository";
 
 export type ProfileUpsertInput = {
-  id: string;
-  email?: string | null;
+  authUserId: string;
   name?: string | null;
-  /** Required on create. Update path leaves the existing username untouched. */
-  username: string;
+  /** Required on create. Update path leaves the existing handle untouched. */
+  handle: string;
   avatarUrl?: string | null;
 };
 
 export type ProfileUpdateInput = {
   name?: string | null;
-  username?: string;
+  handle?: string;
   bio?: string | null;
   avatarUrl?: string | null;
 };
@@ -24,23 +23,25 @@ export class ProfileRepository extends BaseRepository {
     return this.client.profile.findUnique({ where: { id } });
   }
 
-  async findByUsername(username: string): Promise<Profile | null> {
-    return this.client.profile.findUnique({ where: { username } });
+  async findByAuthUserId(authUserId: string): Promise<Profile | null> {
+    return this.client.profile.findUnique({ where: { authUserId } });
+  }
+
+  async findByHandle(handle: string): Promise<Profile | null> {
+    return this.client.profile.findUnique({ where: { handle } });
   }
 
   async upsert(input: ProfileUpsertInput): Promise<Profile> {
     return this.client.profile.upsert({
-      where: { id: input.id },
+      where: { authUserId: input.authUserId },
       update: {
-        email: input.email ?? null,
         name: input.name ?? null,
         avatarUrl: input.avatarUrl ?? null,
       },
       create: {
-        id: input.id,
-        email: input.email ?? null,
+        authUserId: input.authUserId,
         name: input.name ?? null,
-        username: input.username,
+        handle: input.handle,
         avatarUrl: input.avatarUrl ?? null,
       },
     });

--- a/src/repositories/search.repository.ts
+++ b/src/repositories/search.repository.ts
@@ -6,7 +6,7 @@ import { BaseRepository } from "./base.repository";
 
 export type CourseSearchHit = Prisma.CourseGetPayload<{
   include: {
-    author: { select: { id: true; name: true; username: true; avatarUrl: true } };
+    author: { select: { id: true; name: true; handle: true; avatarUrl: true } };
     lessons: { where: { isPublished: true }; select: { id: true } };
   };
 }>;
@@ -18,7 +18,7 @@ export type LessonSearchHit = Prisma.LessonGetPayload<{
         id: true;
         slug: true;
         title: true;
-        author: { select: { id: true; name: true; username: true } };
+        author: { select: { id: true; name: true; handle: true } };
       };
     };
   };
@@ -37,7 +37,7 @@ export class SearchRepository extends BaseRepository {
       orderBy: { createdAt: "desc" },
       take: SEARCH_LIMIT,
       include: {
-        author: { select: { id: true, name: true, username: true, avatarUrl: true } },
+        author: { select: { id: true, name: true, handle: true, avatarUrl: true } },
         lessons: {
           where: { isPublished: true },
           select: { id: true },
@@ -65,7 +65,7 @@ export class SearchRepository extends BaseRepository {
             id: true,
             slug: true,
             title: true,
-            author: { select: { id: true, name: true, username: true } },
+            author: { select: { id: true, name: true, handle: true } },
           },
         },
       },

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -3,25 +3,83 @@ import "server-only";
 import type { Profile } from "@prisma/client";
 import { handleUnknownError, ValidationError } from "@/lib/errors";
 import { logError, logInfo } from "@/lib/logging";
-import { type ProfileRepository, type ProfileUpdateInput, profileRepository } from "@/repositories";
+import { OFFICIAL_HANDLE } from "@/lib/routes";
+import {
+  type HandleReservationRepository,
+  handleReservationRepository,
+  type ProfileRepository,
+  type ProfileUpdateInput,
+  profileRepository,
+} from "@/repositories";
 
+export type UpdateProfileDeps = {
+  profile?: ProfileRepository;
+  reservation?: HandleReservationRepository;
+  now?: () => Date;
+};
+
+/**
+ * Update a Profile, enforcing the 90-day handle reservation rule.
+ *
+ * When the handle changes we (1) reject reserved namespaces, (2) reject
+ * handles parked by an earlier rename whose cooldown has not elapsed,
+ * (3) write the update (the unique constraint catches concurrent races),
+ * and (4) park the previous handle so old `/courses/{handle}/...` URLs
+ * do not silently start resolving to a different person.
+ */
 export async function updateProfile(
   userId: string,
   data: ProfileUpdateInput,
-  repository: ProfileRepository = profileRepository,
+  deps: UpdateProfileDeps = {},
 ): Promise<Profile> {
+  const profileRepo = deps.profile ?? profileRepository;
+  const reservationRepo = deps.reservation ?? handleReservationRepository;
+  const now = deps.now ?? (() => new Date());
+
   logInfo("profileService.updateProfile.start", { userId });
   try {
-    const updated = await repository.update(userId, data);
+    const current = await profileRepo.findById(userId);
+    if (!current) {
+      throw new ValidationError("プロフィールが見つかりません");
+    }
+
+    const handleChanged = data.handle !== undefined && data.handle !== current.handle;
+    if (handleChanged && data.handle) {
+      await assertHandleAvailable(data.handle, reservationRepo, now());
+    }
+
+    const updated = await profileRepo.update(userId, data);
+
+    if (handleChanged) {
+      await reservationRepo.reserve(current.handle, now());
+    }
+
     logInfo("profileService.updateProfile.success", { userId });
     return updated;
   } catch (error) {
-    if (isUniqueConstraintError(error, "username")) {
-      logInfo("profileService.updateProfile.duplicateUsername", { userId });
-      throw new ValidationError("このユーザー名は既に使われています");
+    if (error instanceof ValidationError) {
+      throw error;
+    }
+    if (isUniqueConstraintError(error, "handle")) {
+      logInfo("profileService.updateProfile.duplicateHandle", { userId });
+      throw new ValidationError("このハンドルは既に使われています");
     }
     logError("profileService.updateProfile.error", { userId }, error);
     throw handleUnknownError(error);
+  }
+}
+
+async function assertHandleAvailable(
+  handle: string,
+  reservationRepo: HandleReservationRepository,
+  now: Date,
+): Promise<void> {
+  if (handle === OFFICIAL_HANDLE) {
+    throw new ValidationError("このハンドルは使用できません");
+  }
+  const reservation = await reservationRepo.findByHandle(handle);
+  if (reservation && reservation.releasedAt > now) {
+    throw new ValidationError("このハンドルは現在使用できません (予約期間中)");
   }
 }
 

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -2,14 +2,14 @@ import { z } from "zod";
 import { OFFICIAL_HANDLE } from "@/lib/routes";
 
 // Lower-case only: course URLs of the form /courses/{handle}/{slug} resolve
-// the handle via a case-sensitive Postgres unique on Profile.username, so a
+// the handle via a case-sensitive Postgres unique on Profile.handle, so a
 // mixed-case handle would silently 404 when the URL is shared lower-cased.
-const USERNAME_REGEX = /^[a-z0-9_-]+$/;
+const HANDLE_REGEX = /^[a-z0-9_-]+$/;
 
 // Reserved handles that own dedicated /courses/{handle}/... namespaces and so
 // must never be claimed by an end user. `official` is the public alias for
 // authorId IS NULL courses; expand this list as more reserved namespaces appear.
-const RESERVED_USERNAMES: readonly string[] = [OFFICIAL_HANDLE];
+const RESERVED_HANDLES: readonly string[] = [OFFICIAL_HANDLE];
 
 // Empty strings from the edit form mean "clear this optional field". Normalise
 // them to null up-front so the rest of the schema can stay tight.
@@ -18,13 +18,13 @@ const optionalText = <S extends z.ZodTypeAny>(schema: S) =>
 
 export const UpdateProfileSchema = z.object({
   name: z.string().trim().min(1, "名前を入力してください").max(50, "50 文字以内で入力してください"),
-  username: z
+  handle: z
     .string()
     .trim()
     .min(2, "2 文字以上で入力してください")
     .max(30, "30 文字以内で入力してください")
-    .regex(USERNAME_REGEX, "小文字英数字、_、- のみ使用できます")
-    .refine((v) => !RESERVED_USERNAMES.includes(v.toLowerCase()), "このユーザー名は使用できません"),
+    .regex(HANDLE_REGEX, "小文字英数字、_、- のみ使用できます")
+    .refine((v) => !RESERVED_HANDLES.includes(v.toLowerCase()), "このハンドルは使用できません"),
   bio: optionalText(z.string().trim().max(200, "200 文字以内で入力してください")),
   avatarUrl: optionalText(
     z


### PR DESCRIPTION
## Summary

Closes #69. Splits `Profile.id` (today equal to `auth.users.id`) from the auth identifier so the application owns its own primary keys, drops the duplicated `Profile.email`, and reshapes the mutable URL handle behind a 90-day reservation table to close the time-axis URL collision discussed in the issue.

- `Profile.id`: UUID → cuid; new `auth_user_id UUID UNIQUE` keeps the link to `auth.users`
- `Profile.email` removed (auth.users is the source of truth)
- `Profile.username` → `Profile.handle`
- New `HandleReservation(handle PK, released_at, created_at)` parks renamed handles for 90 days

All Course / Bookmark / Notification / Progress FKs migrate from UUID to TEXT and now reference the cuid Profile.id.

## Migration shape

7 sequential migrations, each verified end-to-end against the docker shadow DB with seeded fixtures:

1. `20260427100000_add_profile_auth_user_id_and_cuid` — add `auth_user_id` + `id_new`, back-fill, add unique indexes
2. `20260427100100_repoint_fks_to_profile_id_new` — add `*_id_new` TEXT cols on every dependent table, JOIN-populate, swap FK constraints
3. `20260427100200_swap_profile_pk` — drop legacy `profiles.id` (UUID), promote `id_new` to PK in place (FKs unaffected)
4. `20260427100300_swap_fk_columns` — drop legacy `*_id` columns, rename `*_id_new` back, recreate index/constraint names
5. `20260427100400_drop_profile_email` — drop `profiles.email`
6. `20260427100500_rename_username_to_handle` — column + unique index rename, drop redundant non-unique index
7. `20260427100600_add_handle_reservation` — create `handle_reservations`

Existing data is preserved through the entire sequence — no `DROP COLUMN` happens before its successor column is back-filled and FK-constrained.

## Application changes

- `ProfileRepository.findByAuthUserId` / `findByHandle` (the old `findByUsername` is replaced)
- New `HandleReservationRepository` (`findByHandle`, `reserve`, `purgeExpired`)
- `requireAuth` now resolves the Profile by `authUserId`; `session.userId` exposes the cuid Profile.id (FKs use this)
- `profileService.updateProfile` enforces the reservation rule: blocks `official`, blocks handles parked within 90 days, parks the previous handle on rename
- `UpdateProfileSchema` / Server Action / `/me/edit` form rename the field to `handle`, with copy explaining the 90-day cooldown
- `routes.ts`, `CourseRepository.findPublishedByHandleAndSlug...`, search and bookmark selects all switch to `handle`

## Operational note (post-merge)

`prisma/sql/001_profiles_trigger.sql` is rewritten for the new schema (cuid Profile.id, `ON CONFLICT (auth_user_id)`, handle default `user_<12 hex>`). After the migrations land in Supabase, **re-apply the trigger SQL** via the Supabase SQL editor or `psql "$DIRECT_URL" -f prisma/sql/001_profiles_trigger.sql`. The old trigger references `profiles.email` / `profiles.username` and will fail until the file is replaced.

## Test plan

- [x] `npm run check` (biome) passes
- [x] `npx tsc --noEmit` passes (after `npx next typegen`)
- [x] `npm run build` succeeds
- [x] `prisma migrate deploy` applies all 7 migrations on a fresh shadow DB
- [x] `prisma migrate deploy` applies cleanly on a populated shadow DB (seeded with 2 profiles + course + lesson + bookmark + notification + progress) with no row loss
- [x] `prisma migrate diff --from-migrations --to-schema` reports no drift
- [ ] After merge: re-apply `prisma/sql/001_profiles_trigger.sql` in Supabase, sign in, edit handle, confirm `/courses/{new-handle}/...` resolves and `/courses/{old-handle}/...` 404s during cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)