### PR TITLE
feat(ui): 公式/UGC 分離後の UI 整理 (Closes #73)

### DIFF
--- a/src/app/(protected)/[handle]/bookmarks/_components/BookmarksTabs.tsx
+++ b/src/app/(protected)/[handle]/bookmarks/_components/BookmarksTabs.tsx
@@ -1,0 +1,72 @@
+import { ShieldCheck, Users } from "lucide-react";
+import Link from "next/link";
+import { bookmarksUrl } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+
+export type BookmarkTab = "official" | "community";
+
+type Props = {
+  handle: string;
+  active: BookmarkTab;
+  officialCount: number;
+  communityCount: number;
+};
+
+const TABS: ReadonlyArray<{
+  key: BookmarkTab;
+  label: string;
+  Icon: typeof ShieldCheck;
+}> = [
+  { key: "official", label: "公式", Icon: ShieldCheck },
+  { key: "community", label: "コミュニティ", Icon: Users },
+];
+
+export function BookmarksTabs({ handle, active, officialCount, communityCount }: Props) {
+  const counts: Record<BookmarkTab, number> = {
+    official: officialCount,
+    community: communityCount,
+  };
+  const base = bookmarksUrl(handle);
+
+  return (
+    <nav
+      aria-label="ブックマークタブ"
+      className="mb-6 flex gap-1 rounded-[10px] p-[3px]"
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)", width: "fit-content" }}
+    >
+      {TABS.map(({ key, label, Icon }) => {
+        const isActive = key === active;
+        const href = key === "official" ? base : `${base}?tab=community`;
+        return (
+          <Link
+            key={key}
+            href={href}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-[6px] px-3.5 py-1.5 font-medium text-[13px] transition",
+            )}
+            style={{
+              color: isActive ? "var(--text-1)" : "var(--text-3)",
+              background: isActive ? "var(--bg-3)" : "transparent",
+            }}
+          >
+            <Icon
+              aria-hidden="true"
+              className="size-3.5"
+              style={{ color: isActive ? "var(--accent-solid)" : undefined }}
+            />
+            {label}
+            <span className="cm-mono text-[11.5px] font-normal" style={{ color: "var(--text-3)" }}>
+              {counts[key]}
+            </span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function parseBookmarkTab(value: string | string[] | undefined): BookmarkTab {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return raw === "community" ? "community" : "official";
+}

--- a/src/app/(protected)/[handle]/bookmarks/page.tsx
+++ b/src/app/(protected)/[handle]/bookmarks/page.tsx
@@ -8,12 +8,18 @@ import { BookmarkCollectionList } from "./_components/BookmarkCollectionList";
 import { BookmarkCourseList } from "./_components/BookmarkCourseList";
 import { BookmarkLessonList } from "./_components/BookmarkLessonList";
 import { BookmarkProblemList } from "./_components/BookmarkProblemList";
+import { BookmarksTabs, parseBookmarkTab } from "./_components/BookmarksTabs";
 
 export const dynamic = "force-dynamic";
 
-export default async function BookmarksPage({ params }: PageProps<"/[handle]/bookmarks">) {
+export default async function BookmarksPage({
+  params,
+  searchParams,
+}: PageProps<"/[handle]/bookmarks">) {
   const session = await requireAuth();
   const { handle } = await params;
+  const sp = await searchParams;
+  const activeTab = parseBookmarkTab(sp?.tab);
 
   const viewedProfile = await getProfileByHandle(handle);
   if (!viewedProfile) notFound();
@@ -28,7 +34,9 @@ export default async function BookmarksPage({ params }: PageProps<"/[handle]/boo
   // a future change loosened the isOwner gate above, the data fetch itself
   // would still be scoped to one user — Layer C defence in depth.
   const { courses, lessons, collections, problems } = await getUserBookmarks(viewedProfile.id);
-  const total = courses.length + lessons.length + collections.length + problems.length;
+  const officialCount = courses.length + lessons.length;
+  const communityCount = collections.length + problems.length;
+  const total = officialCount + communityCount;
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
@@ -38,7 +46,7 @@ export default async function BookmarksPage({ params }: PageProps<"/[handle]/boo
           <h1 className="m-0 font-bold text-[26px] tracking-tight">お気に入り</h1>
         </div>
         <p className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
-          コース・レッスン・コレクション・問題の Star を集めた一覧
+          公式コンテンツとコミュニティの Star を分けて表示します
         </p>
       </header>
 
@@ -56,12 +64,48 @@ export default async function BookmarksPage({ params }: PageProps<"/[handle]/boo
             コレクションを探す →
           </Link>
         </div>
-      ) : null}
+      ) : (
+        <>
+          <BookmarksTabs
+            handle={viewedProfile.handle}
+            active={activeTab}
+            officialCount={officialCount}
+            communityCount={communityCount}
+          />
+          {activeTab === "official" ? (
+            officialCount === 0 ? (
+              <EmptyTab message="公式コンテンツのお気に入りはまだありません。" />
+            ) : (
+              <>
+                <BookmarkCourseList courses={courses} />
+                <BookmarkLessonList lessons={lessons} />
+              </>
+            )
+          ) : communityCount === 0 ? (
+            <EmptyTab message="コミュニティのお気に入りはまだありません。" />
+          ) : (
+            <>
+              <BookmarkCollectionList collections={collections} />
+              <BookmarkProblemList problems={problems} />
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
 
-      <BookmarkCourseList courses={courses} />
-      <BookmarkLessonList lessons={lessons} />
-      <BookmarkCollectionList collections={collections} />
-      <BookmarkProblemList problems={problems} />
+function EmptyTab({ message }: { message: string }) {
+  return (
+    <div
+      className="rounded-[14px] px-8 py-12 text-center text-[13px]"
+      style={{
+        background: "var(--bg-1)",
+        border: "1px dashed var(--line-3)",
+        color: "var(--text-3)",
+      }}
+    >
+      {message}
     </div>
   );
 }

--- a/src/app/(protected)/_components/CollectionCard.tsx
+++ b/src/app/(protected)/_components/CollectionCard.tsx
@@ -1,20 +1,9 @@
-import { BookText } from "lucide-react";
-import Link from "next/link";
+import { ContentCard } from "@/components/content/ContentCard";
+import { HandleLink } from "@/components/profile/HandleLink";
 import { collectionUrl } from "@/lib/routes";
 import { cn } from "@/lib/utils";
-import type { CollectionAuthor, CollectionWithProblemsAndAuthor } from "@/repositories";
+import type { CollectionWithProblemsAndAuthor } from "@/repositories";
 import { coverFor, glyphFor } from "./courseCover";
-
-function authorLabel(author: CollectionAuthor): string {
-  // Fall back to "Anonymous" when the author didn't set a display name —
-  // do NOT derive a handle from any auth identifier (privacy).
-  return author.name ?? "Anonymous";
-}
-
-function authorInitial(author: CollectionAuthor): string {
-  const label = authorLabel(author);
-  return (Array.from(label.trim())[0] ?? "?").toUpperCase();
-}
 
 type Props = {
   collection: CollectionWithProblemsAndAuthor;
@@ -25,70 +14,26 @@ type Props = {
 export function CollectionCard({ collection, index, completedIds }: Props) {
   const total = collection.problems.length;
   const done = collection.problems.filter((p) => completedIds.has(p.id)).length;
-  const pct = total === 0 ? 0 : Math.round((done / total) * 100);
 
   return (
-    <Link
+    <ContentCard
       href={collectionUrl(collection)}
-      className={cn(
-        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
-        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
-      )}
-      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-    >
-      <div className={cn("cm-cover", coverFor(index))}>
-        <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
-          <span className="cm-diff-badge cm-diff-1">初級</span>
-        </div>
-        <span className="cm-cover-glyph" aria-hidden="true">
-          {glyphFor(collection.title)}
-        </span>
-      </div>
-      <div className="flex flex-1 flex-col gap-2.5 p-4">
-        <h3
-          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
-          style={{ color: "var(--text-1)" }}
-        >
-          {collection.title}
-        </h3>
-
-        <div className="flex items-center gap-1.5">
-          <span className="cm-avatar cm-avatar-sm" aria-hidden="true">
-            {authorInitial(collection.author)}
-          </span>
-          <span className="text-[12px]" style={{ color: "var(--text-3)" }}>
-            {authorLabel(collection.author)}
-          </span>
-        </div>
-
-        {collection.description ? (
-          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
-            {collection.description}
-          </p>
-        ) : null}
-
-        <div className="flex flex-wrap gap-1.5">
-          <span className="cm-chip">#コミュニティ</span>
-        </div>
-
-        <div className="mt-auto flex items-center gap-3">
-          <div className="cm-progress flex-1">
-            <span style={{ width: `${pct}%` }} />
+      title={collection.title}
+      description={collection.description}
+      cover={
+        <div className={cn("cm-cover", coverFor(index))}>
+          <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
+            <span className="cm-diff-badge cm-diff-1">初級</span>
           </div>
-          <span className="cm-mono" style={{ color: "var(--text-3)" }}>
-            {done}/{total}
+          <span className="cm-cover-glyph" aria-hidden="true">
+            {glyphFor(collection.title)}
           </span>
         </div>
-        <div
-          className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
-          style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
-        >
-          <span className="inline-flex items-center gap-1">
-            <BookText className="size-3" aria-hidden="true" />
-            <b style={{ color: "var(--text-1)" }}>{total}</b> 問題
-          </span>
-        </div>
-      </div>
-    </Link>
+      }
+      byline={<HandleLink author={collection.author} />}
+      chips={<span className="cm-chip">#コミュニティ</span>}
+      progress={{ done, total }}
+      countLabel={{ count: total, suffix: "問題" }}
+    />
   );
 }

--- a/src/app/(protected)/_components/CourseCard.tsx
+++ b/src/app/(protected)/_components/CourseCard.tsx
@@ -1,5 +1,5 @@
-import { BookText } from "lucide-react";
-import Link from "next/link";
+import { ContentCard } from "@/components/content/ContentCard";
+import { OfficialBadge } from "@/components/content/OfficialBadge";
 import { learnUrl } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 import type { CourseWithLessons } from "@/repositories";
@@ -14,71 +14,31 @@ type Props = {
 export function CourseCard({ course, index, completedIds }: Props) {
   const total = course.lessons.length;
   const done = course.lessons.filter((l) => completedIds.has(l.id)).length;
-  const pct = total === 0 ? 0 : Math.round((done / total) * 100);
 
   return (
-    <Link
+    <ContentCard
       href={learnUrl(course)}
-      className={cn(
-        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
-        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
-      )}
-      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-    >
-      <div className={cn("cm-cover", coverFor(index))}>
-        <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
-          <span className="cm-diff-badge cm-diff-1">初級</span>
-        </div>
-        <span className="cm-cover-glyph" aria-hidden="true">
-          {glyphFor(course.title)}
-        </span>
-      </div>
-      <div className="flex flex-1 flex-col gap-2.5 p-4">
-        <h3
-          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
-          style={{ color: "var(--text-1)" }}
-        >
-          {course.title}
-        </h3>
-
-        <div className="flex items-center gap-1.5">
-          <span className="cm-avatar cm-avatar-sm" aria-hidden="true">
-            ✓
-          </span>
-          <span className="text-[12px]" style={{ color: "var(--text-3)" }}>
-            公式
+      title={course.title}
+      description={course.description}
+      cover={
+        <div className={cn("cm-cover", coverFor(index))}>
+          <div className="absolute top-2.5 left-2.5 z-10 flex gap-1.5">
+            <span className="cm-diff-badge cm-diff-1">初級</span>
+          </div>
+          <span className="cm-cover-glyph" aria-hidden="true">
+            {glyphFor(course.title)}
           </span>
         </div>
-
-        {course.description ? (
-          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
-            {course.description}
-          </p>
-        ) : null}
-
-        <div className="flex flex-wrap gap-1.5">
+      }
+      topBadge={<OfficialBadge size="sm" />}
+      chips={
+        <>
           <span className="cm-chip">#TypeScript</span>
           <span className="cm-chip">#基礎</span>
-        </div>
-
-        <div className="mt-auto flex items-center gap-3">
-          <div className="cm-progress flex-1">
-            <span style={{ width: `${pct}%` }} />
-          </div>
-          <span className="cm-mono" style={{ color: "var(--text-3)" }}>
-            {done}/{total}
-          </span>
-        </div>
-        <div
-          className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
-          style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
-        >
-          <span className="inline-flex items-center gap-1">
-            <BookText className="size-3" aria-hidden="true" />
-            <b style={{ color: "var(--text-1)" }}>{total}</b> レッスン
-          </span>
-        </div>
-      </div>
-    </Link>
+        </>
+      }
+      progress={{ done, total }}
+      countLabel={{ count: total, suffix: "レッスン" }}
+    />
   );
 }

--- a/src/app/(protected)/search/_components/SearchSectionCommunity.tsx
+++ b/src/app/(protected)/search/_components/SearchSectionCommunity.tsx
@@ -1,0 +1,34 @@
+import { Users } from "lucide-react";
+import type { CollectionSearchHit, ProblemSearchHit } from "@/repositories";
+import { SearchResultCollections } from "./SearchResultCollections";
+import { SearchResultProblems } from "./SearchResultProblems";
+
+type Props = {
+  collections: CollectionSearchHit[];
+  problems: ProblemSearchHit[];
+};
+
+export function SearchSectionCommunity({ collections, problems }: Props) {
+  const total = collections.length + problems.length;
+  if (total === 0) return null;
+
+  return (
+    <section aria-labelledby="search-section-community">
+      <h2
+        id="search-section-community"
+        className="m-0 mb-4 flex items-center gap-2 font-bold text-[18px] tracking-tight"
+        style={{ color: "var(--text-1)" }}
+      >
+        <Users aria-hidden="true" className="size-4" style={{ color: "var(--text-2)" }} />
+        コミュニティ
+        <span className="cm-mono font-normal text-[12.5px]" style={{ color: "var(--text-3)" }}>
+          {total} 件
+        </span>
+      </h2>
+      <div className="flex flex-col gap-7">
+        <SearchResultCollections collections={collections} />
+        <SearchResultProblems problems={problems} />
+      </div>
+    </section>
+  );
+}

--- a/src/app/(protected)/search/_components/SearchSectionOfficial.tsx
+++ b/src/app/(protected)/search/_components/SearchSectionOfficial.tsx
@@ -1,0 +1,38 @@
+import { ShieldCheck } from "lucide-react";
+import type { CourseSearchHit, LessonSearchHit } from "@/repositories";
+import { SearchResultCourses } from "./SearchResultCourses";
+import { SearchResultLessons } from "./SearchResultLessons";
+
+type Props = {
+  courses: CourseSearchHit[];
+  lessons: LessonSearchHit[];
+};
+
+export function SearchSectionOfficial({ courses, lessons }: Props) {
+  const total = courses.length + lessons.length;
+  if (total === 0) return null;
+
+  return (
+    <section aria-labelledby="search-section-official">
+      <h2
+        id="search-section-official"
+        className="m-0 mb-4 flex items-center gap-2 font-bold text-[18px] tracking-tight"
+        style={{ color: "var(--text-1)" }}
+      >
+        <ShieldCheck
+          aria-hidden="true"
+          className="size-4"
+          style={{ color: "var(--accent-solid)" }}
+        />
+        公式コース
+        <span className="cm-mono font-normal text-[12.5px]" style={{ color: "var(--text-3)" }}>
+          {total} 件
+        </span>
+      </h2>
+      <div className="flex flex-col gap-7">
+        <SearchResultCourses courses={courses} />
+        <SearchResultLessons lessons={lessons} />
+      </div>
+    </section>
+  );
+}

--- a/src/app/(protected)/search/page.tsx
+++ b/src/app/(protected)/search/page.tsx
@@ -2,10 +2,8 @@ import { MIN_QUERY_LENGTH } from "@/config/search";
 import { requireAuth } from "@/lib/auth";
 import { search } from "@/services/searchService";
 import { EmptyState } from "./_components/EmptyState";
-import { SearchResultCollections } from "./_components/SearchResultCollections";
-import { SearchResultCourses } from "./_components/SearchResultCourses";
-import { SearchResultLessons } from "./_components/SearchResultLessons";
-import { SearchResultProblems } from "./_components/SearchResultProblems";
+import { SearchSectionCommunity } from "./_components/SearchSectionCommunity";
+import { SearchSectionOfficial } from "./_components/SearchSectionOfficial";
 
 export const dynamic = "force-dynamic";
 
@@ -42,11 +40,9 @@ export default async function SearchPage({ searchParams }: PageProps<"/search">)
           description="別のキーワードで検索してみてください。"
         />
       ) : (
-        <div className="flex flex-col gap-10">
-          <SearchResultCourses courses={courses} />
-          <SearchResultLessons lessons={lessons} />
-          <SearchResultCollections collections={collections} />
-          <SearchResultProblems problems={problems} />
+        <div className="flex flex-col gap-12">
+          <SearchSectionOfficial courses={courses} lessons={lessons} />
+          <SearchSectionCommunity collections={collections} problems={problems} />
         </div>
       )}
     </div>

--- a/src/components/content/ContentCard.tsx
+++ b/src/components/content/ContentCard.tsx
@@ -1,0 +1,100 @@
+import { BookText } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type ContentCardProps = {
+  href: string;
+  title: string;
+  description?: string | null;
+  cover: ReactNode;
+  /** Rendered above the title (e.g. <OfficialBadge />). */
+  topBadge?: ReactNode;
+  /** Rendered between title and progress (e.g. <HandleLink /> or "公式" label). */
+  byline?: ReactNode;
+  /** Tag chips. */
+  chips?: ReactNode;
+  /** Progress 0..1; null hides the bar. */
+  progress?: { done: number; total: number } | null;
+  /** Footer label, e.g. "12 レッスン" or "8 問題". */
+  countLabel?: { count: number; suffix: string };
+};
+
+/**
+ * Shared card primitive for /learn (CourseCard) and / (CollectionCard).
+ * The card itself is *not* an anchor so children like <HandleLink> can be
+ * real anchors without nesting (which is invalid HTML). The destination
+ * link is placed on the cover + title only.
+ */
+export function ContentCard({
+  href,
+  title,
+  description,
+  cover,
+  topBadge,
+  byline,
+  chips,
+  progress,
+  countLabel,
+}: ContentCardProps) {
+  const pct =
+    progress && progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0;
+
+  return (
+    <article
+      className={cn(
+        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
+        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
+      )}
+      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+    >
+      <Link href={href} className="relative block">
+        {cover}
+        {topBadge ? <span className="absolute top-2.5 right-2.5 z-10">{topBadge}</span> : null}
+      </Link>
+      <div className="flex flex-1 flex-col gap-2.5 p-4">
+        <Link href={href} className="block">
+          <h3
+            className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight transition group-hover:opacity-90"
+            style={{ color: "var(--text-1)" }}
+          >
+            {title}
+          </h3>
+        </Link>
+
+        {byline ? <div className="flex items-center gap-1.5">{byline}</div> : null}
+
+        {description ? (
+          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
+            {description}
+          </p>
+        ) : null}
+
+        {chips ? <div className="flex flex-wrap gap-1.5">{chips}</div> : null}
+
+        {progress ? (
+          <div className="mt-auto flex items-center gap-3">
+            <div className="cm-progress flex-1">
+              <span style={{ width: `${pct}%` }} />
+            </div>
+            <span className="cm-mono" style={{ color: "var(--text-3)" }}>
+              {progress.done}/{progress.total}
+            </span>
+          </div>
+        ) : null}
+
+        {countLabel ? (
+          <div
+            className="flex items-center gap-3 border-t pt-2.5 text-[12px]"
+            style={{ borderColor: "var(--line-1)", color: "var(--text-3)" }}
+          >
+            <span className="inline-flex items-center gap-1">
+              <BookText className="size-3" aria-hidden="true" />
+              <b style={{ color: "var(--text-1)" }}>{countLabel.count}</b> {countLabel.suffix}
+            </span>
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/src/components/content/OfficialBadge.tsx
+++ b/src/components/content/OfficialBadge.tsx
@@ -1,0 +1,29 @@
+import { ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  className?: string;
+  size?: "sm" | "md";
+};
+
+export function OfficialBadge({ className, size = "md" }: Props) {
+  const isSm = size === "sm";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full font-semibold tracking-tight",
+        isSm ? "px-1.5 py-0.5 text-[10.5px]" : "px-2 py-0.5 text-[11px]",
+        className,
+      )}
+      style={{
+        background: "var(--accent-soft)",
+        color: "var(--accent-solid)",
+        border: "1px solid var(--accent-line, var(--accent-solid))",
+      }}
+      title="公式コンテンツ"
+    >
+      <ShieldCheck aria-hidden="true" className={isSm ? "size-2.5" : "size-3"} />
+      公式
+    </span>
+  );
+}

--- a/src/components/profile/HandleLink.tsx
+++ b/src/components/profile/HandleLink.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { profileUrl } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+
+export type HandleLinkAuthor = {
+  handle: string;
+  name: string | null;
+  avatarUrl: string | null;
+};
+
+type Props = {
+  author: HandleLinkAuthor;
+  size?: "xs" | "sm" | "md";
+  showHandle?: boolean;
+  className?: string;
+};
+
+function initial(value: string): string {
+  return (Array.from(value.trim())[0] ?? "?").toUpperCase();
+}
+
+export function HandleLink({ author, size = "sm", showHandle = false, className }: Props) {
+  const displayName = author.name ?? author.handle;
+  const avatarSize = size === "xs" ? "size-4" : size === "sm" ? "size-5" : "size-6";
+  const textSize = size === "xs" ? "text-[11px]" : size === "sm" ? "text-[12px]" : "text-[13px]";
+
+  return (
+    <Link
+      href={profileUrl(author.handle)}
+      className={cn(
+        "group/handle inline-flex items-center gap-1.5 rounded-full transition hover:opacity-90",
+        className,
+      )}
+    >
+      {author.avatarUrl ? (
+        // biome-ignore lint/performance/noImgElement: avatar URLs are user-supplied (Supabase Storage / external); switching to next/image would require configuring remotePatterns for every host
+        <img
+          src={author.avatarUrl}
+          alt=""
+          aria-hidden="true"
+          className={cn(avatarSize, "shrink-0 rounded-full object-cover")}
+          style={{ background: "var(--bg-2)" }}
+        />
+      ) : (
+        <span
+          aria-hidden="true"
+          className={cn(
+            avatarSize,
+            "inline-flex shrink-0 items-center justify-center rounded-full font-semibold text-[10px]",
+          )}
+          style={{ background: "var(--bg-2)", color: "var(--text-2)" }}
+        >
+          {initial(displayName)}
+        </span>
+      )}
+      <span
+        className={cn(textSize, "truncate group-hover/handle:underline")}
+        style={{ color: "var(--text-2)" }}
+      >
+        {showHandle ? `@${author.handle}` : displayName}
+      </span>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

- 公式 (`Course`/`Lesson`) と UGC (`Collection`/`Problem`) の分離を UI に反映する。共通カード基盤として `ContentCard` / `OfficialBadge` / `HandleLink` を導入し、`CourseCard` / `CollectionCard` を組み立て直した。
- `/search` の結果は **公式コース** と **コミュニティ** の 2 セクションに集約。内側の Course/Lesson と Collection/Problem サブリストは温存。
- `/{handle}/bookmarks` は `?tab=official|community` の Server-side タブ駆動で 2 タブ化。Server Component のまま、Link クリックで URL が切り替わる。
- `CollectionCard` がプロフィール (`/{handle}`) への `HandleLink` を露出するようになり、card 全体は `<article>`、`HandleLink` は実 `<a>` に分かれてネスト anchor を解消。

## ⚠️ Stacked PR 第 3 段

- 本 PR は **#75 (`feature/issue-72-routing`) を base** に積まれている。`#75` は **#74 (`feature/issue-71-schema-split`) を base** に積まれている。
- 順次マージ (#74 → #75 → 本 PR) で、最終的に base が `main` に解決される。先頭からマージしないと diff が捏造されるので注意。
- マージ順を逆転させたい場合は本 PR を `--base main` にリベースする必要がある。

## スコープ外 (本 PR では触らない)

- フィルタ・ソートの実機能化 (UI は disabled のまま)
- いいね / コメント / フォロー
- 公式 Course の作成 / 編集 (ADMIN role 未実装)
- 通知の作成元 (createNotification を呼び出す call site は未実装)。`linkUrl` の検証ロジック (`assertSafeLinkUrl`) は #72 で導入済みで、新 URL 体系のまま素通しできるため変更不要。

## Test plan

- [ ] `/learn` でコースカードに公式バッジが表示される
- [ ] `/` でコレクションカードのハンドルから `/{handle}` に遷移できる (ネスト anchor で warning が出ない)
- [ ] `/search?q=...` の結果が「公式コース」「コミュニティ」の 2 セクションに分割される
- [ ] `/{自分の handle}/bookmarks` を開くと既定で「公式」タブが選択され、`?tab=community` で「コミュニティ」に切り替わる
- [ ] 自分以外の `/{handle}/bookmarks` は 404 (Layer A guard を踏襲)
- [ ] `npm run check` / `npx tsc --noEmit` / `next build` (DATABASE_URL ダミー) すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)