### PR TITLE
feat(ugc): /[handle]/[collection]/[problem] にコードエディタ + LessonClient 共通化 (Closes #77)

### DIFF
--- a/src/app/(protected)/[handle]/[collection]/[problem]/_components/ProblemSolverClient.tsx
+++ b/src/app/(protected)/[handle]/[collection]/[problem]/_components/ProblemSolverClient.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ArrowLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { completeProblemAction } from "@/actions/progress";
+import { ProblemSolver } from "@/components/problem-solver/ProblemSolver";
+import { type CollectionLinkable, collectionUrl } from "@/lib/routes";
+
+type Problem = {
+  id: string;
+  slug: string;
+  title: string;
+  contentMd: string;
+  starterCode: string;
+  expectedOutput: string | null;
+};
+
+type Props = {
+  collection: CollectionLinkable & { title: string };
+  problem: Problem;
+  initiallyCompleted: boolean;
+};
+
+export function ProblemSolverClient({ collection, problem, initiallyCompleted }: Props) {
+  return (
+    <ProblemSolver
+      title={problem.title}
+      contentMd={problem.contentMd}
+      starterCode={problem.starterCode}
+      expectedOutput={problem.expectedOutput}
+      initialStatus={initiallyCompleted ? "COMPLETED" : "NOT_STARTED"}
+      onSubmit={async ({ passed }) => {
+        if (!passed) return;
+        const result = await completeProblemAction({ problemId: problem.id });
+        if (result?.serverError || result?.validationErrors) {
+          throw new Error("completeProblemAction failed");
+        }
+      }}
+      headerLeft={
+        <>
+          <Link
+            href={collectionUrl(collection)}
+            className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
+            style={{ color: "var(--text-2)" }}
+          >
+            <ArrowLeft className="size-3.5" aria-hidden="true" /> コレクション
+          </Link>
+          <div className="flex items-center gap-1.5 text-[12px]" style={{ color: "var(--text-3)" }}>
+            <span>{collection.title}</span>
+            <ChevronRight className="size-3" aria-hidden="true" />
+            <b style={{ color: "var(--text-1)", fontWeight: 500 }}>問題</b>
+          </div>
+        </>
+      }
+      subtitle={
+        <>
+          {collection.author.handle} / {collection.slug} / {problem.slug}
+        </>
+      }
+    />
+  );
+}

--- a/src/app/(protected)/[handle]/[collection]/[problem]/page.tsx
+++ b/src/app/(protected)/[handle]/[collection]/[problem]/page.tsx
@@ -1,20 +1,17 @@
 import type { Problem } from "@prisma/client";
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { requireAuth } from "@/lib/auth";
 import { NotFoundError } from "@/lib/errors";
-import { collectionUrl } from "@/lib/routes";
 import { getCollectionByHandleAndSlug } from "@/services/collectionService";
+import { isProblemCompleted } from "@/services/progressService";
+import { ProblemSolverClient } from "./_components/ProblemSolverClient";
 
 export const dynamic = "force-dynamic";
 
 export default async function ProblemPage({
   params,
 }: PageProps<"/[handle]/[collection]/[problem]">) {
-  await requireAuth();
+  const session = await requireAuth();
   const { handle, collection: collectionSlug, problem: problemSlug } = await params;
 
   let collection: Awaited<ReturnType<typeof getCollectionByHandleAndSlug>>;
@@ -28,38 +25,24 @@ export default async function ProblemPage({
   const problem = collection.problems.find((p: Problem) => p.slug === problemSlug);
   if (!problem) notFound();
 
-  const collectionLinkable = {
-    slug: collection.slug,
-    author: { handle: collection.author.handle },
-  };
+  const completed = await isProblemCompleted(session.userId, problem.id);
 
   return (
-    <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "880px" }}>
-      <Link
-        href={collectionUrl(collectionLinkable)}
-        className="mb-4 inline-flex items-center gap-1 text-[13px]"
-        style={{ color: "var(--text-3)" }}
-      >
-        <ArrowLeft className="size-3.5" aria-hidden="true" /> {collection.title}
-      </Link>
-
-      <header className="mb-7">
-        <h1 className="m-0 font-bold text-[26px] tracking-tight">{problem.title}</h1>
-        <div className="mt-1.5 font-mono text-[12px]" style={{ color: "var(--text-3)" }}>
-          {collection.author.handle} / {collection.slug} / {problem.slug}
-        </div>
-      </header>
-
-      <article
-        className="prose prose-invert max-w-none rounded-[16px] p-6"
-        style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-      >
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{problem.contentMd}</ReactMarkdown>
-      </article>
-
-      <p className="mt-4 text-[12px]" style={{ color: "var(--text-4)" }}>
-        コードエディタは別 issue で実装予定です。
-      </p>
-    </div>
+    <ProblemSolverClient
+      collection={{
+        slug: collection.slug,
+        title: collection.title,
+        author: { handle: collection.author.handle },
+      }}
+      problem={{
+        id: problem.id,
+        slug: problem.slug,
+        title: problem.title,
+        contentMd: problem.contentMd,
+        starterCode: problem.starterCode,
+        expectedOutput: problem.expectedOutput,
+      }}
+      initiallyCompleted={completed}
+    />
   );
 }

--- a/src/app/(protected)/learn/[course]/[lesson]/_components/LessonSolver.tsx
+++ b/src/app/(protected)/learn/[course]/[lesson]/_components/LessonSolver.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { ArrowLeft, ArrowRight, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { completeLessonAction } from "@/actions/progress";
+import { BookmarkButton } from "@/components/bookmarks/BookmarkButton";
+import { ProblemSolver } from "@/components/problem-solver/ProblemSolver";
+import { type CourseLinkable, learnUrl, lessonUrl } from "@/lib/routes";
+
+type Lesson = {
+  id: string;
+  slug: string;
+  title: string;
+  contentMd: string;
+  starterCode: string;
+  expectedOutput: string | null;
+};
+
+type Props = {
+  course: CourseLinkable;
+  courseTitle: string;
+  lesson: Lesson;
+  prevSlug: string | null;
+  nextSlug: string | null;
+  initiallyCompleted: boolean;
+  initiallyBookmarked: boolean;
+};
+
+export function LessonSolver({
+  course,
+  courseTitle,
+  lesson,
+  prevSlug,
+  nextSlug,
+  initiallyCompleted,
+  initiallyBookmarked,
+}: Props) {
+  return (
+    <ProblemSolver
+      title={lesson.title}
+      contentMd={lesson.contentMd}
+      starterCode={lesson.starterCode}
+      expectedOutput={lesson.expectedOutput}
+      initialStatus={initiallyCompleted ? "COMPLETED" : "NOT_STARTED"}
+      onSubmit={async ({ passed }) => {
+        if (!passed) return;
+        const result = await completeLessonAction({ lessonId: lesson.id });
+        if (result?.serverError || result?.validationErrors) {
+          throw new Error("completeLessonAction failed");
+        }
+      }}
+      headerLeft={
+        <>
+          <Link
+            href={learnUrl(course)}
+            className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
+            style={{ color: "var(--text-2)" }}
+          >
+            <ArrowLeft className="size-3.5" aria-hidden="true" /> コース
+          </Link>
+          <div className="flex items-center gap-1.5 text-[12px]" style={{ color: "var(--text-3)" }}>
+            <span>{courseTitle}</span>
+            <ChevronRight className="size-3" aria-hidden="true" />
+            <b style={{ color: "var(--text-1)", fontWeight: 500 }}>レッスン</b>
+          </div>
+        </>
+      }
+      subtitle={
+        <>
+          #{lesson.slug} · <span className="cm-diff-badge cm-diff-1 align-middle">初級</span>
+        </>
+      }
+      headerRight={
+        <BookmarkButton
+          target="lesson"
+          lessonId={lesson.id}
+          bookmarked={initiallyBookmarked}
+          variant="compact"
+        />
+      }
+      footerLeft={
+        <>
+          {prevSlug ? (
+            <Link
+              href={lessonUrl(course, prevSlug)}
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
+              style={{
+                background: "var(--bg-2)",
+                border: "1px solid var(--line-2)",
+                color: "var(--text-1)",
+              }}
+            >
+              <ArrowLeft className="size-3.5" aria-hidden="true" /> 前のレッスン
+            </Link>
+          ) : null}
+          {nextSlug ? (
+            <Link
+              href={lessonUrl(course, nextSlug)}
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
+              style={{
+                background: "var(--bg-2)",
+                border: "1px solid var(--line-2)",
+                color: "var(--text-1)",
+              }}
+            >
+              次のレッスン <ArrowRight className="size-3.5" aria-hidden="true" />
+            </Link>
+          ) : null}
+        </>
+      }
+    />
+  );
+}

--- a/src/app/(protected)/learn/[course]/[lesson]/page.tsx
+++ b/src/app/(protected)/learn/[course]/[lesson]/page.tsx
@@ -4,7 +4,7 @@ import { NotFoundError } from "@/lib/errors";
 import { isLessonBookmarked } from "@/services/bookmarkService";
 import { getCourseBySlug } from "@/services/courseService";
 import { isLessonCompleted } from "@/services/progressService";
-import LessonClient from "./_components/LessonClient";
+import { LessonSolver } from "./_components/LessonSolver";
 
 export const dynamic = "force-dynamic";
 
@@ -33,7 +33,7 @@ export default async function LessonPage({ params }: PageProps<"/learn/[course]/
   ]);
 
   return (
-    <LessonClient
+    <LessonSolver
       course={course}
       courseTitle={course.title}
       lesson={{

--- a/src/components/problem-solver/ProblemSolver.tsx
+++ b/src/components/problem-solver/ProblemSolver.tsx
@@ -1,61 +1,60 @@
 "use client";
 
-import {
-  ArrowLeft,
-  ArrowRight,
-  Check,
-  ChevronRight,
-  FileText,
-  Play,
-  RotateCcw,
-  X,
-} from "lucide-react";
+import { Check, FileText, Play, RotateCcw, X } from "lucide-react";
 import dynamic from "next/dynamic";
-import Link from "next/link";
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { BookmarkButton } from "@/components/bookmarks/BookmarkButton";
 import { KEY_NUDGE_PX, MAX_LEFT_RATIO, MIN_LEFT_PX } from "@/config/editor";
-import { type CourseLinkable, learnUrl, lessonUrl } from "@/lib/routes";
 import { cn } from "@/lib/utils";
-import { useLessonRunner } from "../_hooks/useLessonRunner";
+import { type ProblemStatus, type ProblemSubmitResult, useProblemRunner } from "./useProblemRunner";
 
 const MonacoEditor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
 
-type Lesson = {
-  id: string;
-  slug: string;
+export type ProblemSolverProps = {
   title: string;
   contentMd: string;
   starterCode: string;
   expectedOutput: string | null;
+  onSubmit?: (result: ProblemSubmitResult) => Promise<void>;
+  initialStatus?: ProblemStatus;
+  /** Header chrome — left side (breadcrumb / back link). */
+  headerLeft?: ReactNode;
+  /** Small line displayed under the title. */
+  subtitle?: ReactNode;
+  /** Header chrome — right side, appended after the auto-rendered "クリア済み" badge. */
+  headerRight?: ReactNode;
+  /** Footer chrome — left side (e.g. prev / next nav). */
+  footerLeft?: ReactNode;
+  /** Footer chrome — center hint text (overrides the default). */
+  footerHint?: ReactNode;
 };
 
-type Props = {
-  course: CourseLinkable;
-  courseTitle: string;
-  lesson: Lesson;
-  prevSlug: string | null;
-  nextSlug: string | null;
-  initiallyCompleted: boolean;
-  initiallyBookmarked: boolean;
-};
-
-export default function LessonClient({
-  course,
-  courseTitle,
-  lesson,
-  prevSlug,
-  nextSlug,
-  initiallyCompleted,
-  initiallyBookmarked,
-}: Props) {
-  const { code, setCode, output, running, completed, run, reset } = useLessonRunner({
-    lessonId: lesson.id,
-    starterCode: lesson.starterCode,
-    expectedOutput: lesson.expectedOutput,
-    initiallyCompleted,
+export function ProblemSolver({
+  title,
+  contentMd,
+  starterCode,
+  expectedOutput,
+  onSubmit,
+  initialStatus = "NOT_STARTED",
+  headerLeft,
+  subtitle,
+  headerRight,
+  footerLeft,
+  footerHint,
+}: ProblemSolverProps) {
+  const { code, setCode, output, running, completed, run, reset } = useProblemRunner({
+    starterCode,
+    expectedOutput,
+    initialStatus,
+    onSubmit,
   });
 
   const passed =
@@ -64,8 +63,8 @@ export default function LessonClient({
       !output.stderr &&
       !output.timedOut &&
       output.exitCode === 0 &&
-      lesson.expectedOutput !== null &&
-      output.stdout.trim() === lesson.expectedOutput.trim());
+      expectedOutput !== null &&
+      output.stdout.trim() === expectedOutput.trim());
 
   const splitRef = useRef<HTMLDivElement>(null);
   const [leftWidth, setLeftWidth] = useState<number | null>(null);
@@ -151,25 +150,14 @@ export default function LessonClient({
           background: "var(--bg-0)",
         }}
       >
-        <div className="flex items-center gap-3">
-          <Link
-            href={learnUrl(course)}
-            className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
-            style={{ color: "var(--text-2)" }}
-          >
-            <ArrowLeft className="size-3.5" aria-hidden="true" /> コース
-          </Link>
-          <div className="flex items-center gap-1.5 text-[12px]" style={{ color: "var(--text-3)" }}>
-            <span>{courseTitle}</span>
-            <ChevronRight className="size-3" aria-hidden="true" />
-            <b style={{ color: "var(--text-1)", fontWeight: 500 }}>レッスン</b>
-          </div>
-        </div>
+        <div className="flex items-center gap-3">{headerLeft}</div>
         <div className="text-center">
-          <h1 className="m-0 font-semibold text-[15px] tracking-tight">{lesson.title}</h1>
-          <div className="mt-0.5 font-mono text-[11px]" style={{ color: "var(--text-4)" }}>
-            #{lesson.slug} · <span className="cm-diff-badge cm-diff-1 align-middle">初級</span>
-          </div>
+          <h1 className="m-0 font-semibold text-[15px] tracking-tight">{title}</h1>
+          {subtitle ? (
+            <div className="mt-0.5 font-mono text-[11px]" style={{ color: "var(--text-4)" }}>
+              {subtitle}
+            </div>
+          ) : null}
         </div>
         <div className="flex items-center justify-end gap-2">
           {passed ? (
@@ -180,12 +168,7 @@ export default function LessonClient({
               <Check className="size-3" aria-hidden="true" /> クリア済み
             </span>
           ) : null}
-          <BookmarkButton
-            target="lesson"
-            lessonId={lesson.id}
-            bookmarked={initiallyBookmarked}
-            variant="compact"
-          />
+          {headerRight}
         </div>
       </header>
 
@@ -299,10 +282,10 @@ export default function LessonClient({
                   ),
                 }}
               >
-                {lesson.contentMd}
+                {contentMd}
               </ReactMarkdown>
 
-              {lesson.expectedOutput ? (
+              {expectedOutput ? (
                 <section className="mt-6">
                   <h2
                     className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
@@ -331,7 +314,7 @@ export default function LessonClient({
                       className="m-0 p-3 font-mono text-[12.5px] leading-relaxed"
                       style={{ background: "var(--bg-code)", color: "var(--text-1)" }}
                     >
-                      {lesson.expectedOutput}
+                      {expectedOutput}
                     </pre>
                   </div>
                 </section>
@@ -455,7 +438,7 @@ export default function LessonClient({
               className="flex-1 overflow-auto p-4 font-mono text-[12px]"
               style={{ color: "var(--text-1)" }}
             >
-              <ResultBody output={output} expected={lesson.expectedOutput} passed={passed} />
+              <ResultBody output={output} expected={expectedOutput} passed={passed} />
             </div>
           </div>
         </div>
@@ -466,41 +449,13 @@ export default function LessonClient({
         className="grid items-center gap-4 border-t px-5 py-2.5"
         style={{ gridTemplateColumns: "1fr auto 1fr", borderColor: "var(--line-1)" }}
       >
-        <div className="flex gap-2">
-          {prevSlug ? (
-            <Link
-              href={lessonUrl(course, prevSlug)}
-              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
-              style={{
-                background: "var(--bg-2)",
-                border: "1px solid var(--line-2)",
-                color: "var(--text-1)",
-              }}
-            >
-              <ArrowLeft className="size-3.5" aria-hidden="true" /> 前のレッスン
-            </Link>
-          ) : (
-            <span />
-          )}
-          {nextSlug ? (
-            <Link
-              href={lessonUrl(course, nextSlug)}
-              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
-              style={{
-                background: "var(--bg-2)",
-                border: "1px solid var(--line-2)",
-                color: "var(--text-1)",
-              }}
-            >
-              次のレッスン <ArrowRight className="size-3.5" aria-hidden="true" />
-            </Link>
-          ) : null}
-        </div>
+        <div className="flex gap-2">{footerLeft ?? <span />}</div>
         <div
           className="flex items-center gap-1.5 font-mono text-[11px]"
           style={{ color: "var(--text-3)" }}
         >
-          {lesson.expectedOutput ? "期待出力と一致すればクリア" : "実行して動作を確認しよう"}
+          {footerHint ??
+            (expectedOutput ? "期待出力と一致すればクリア" : "実行して動作を確認しよう")}
         </div>
         <div className="flex items-center justify-end gap-2">
           <button
@@ -527,7 +482,7 @@ function ResultBody({
   expected,
   passed,
 }: {
-  output: ReturnType<typeof useLessonRunner>["output"];
+  output: ReturnType<typeof useProblemRunner>["output"];
   expected: string | null;
   passed: boolean;
 }) {

--- a/src/components/problem-solver/useProblemRunner.ts
+++ b/src/components/problem-solver/useProblemRunner.ts
@@ -1,26 +1,28 @@
 "use client";
 
 import { useState } from "react";
-import { completeLessonAction } from "@/actions/progress";
 import { type RunResult, runCodeInBrowser } from "@/lib/run-code";
 
-type Args = {
-  lessonId: string;
-  starterCode: string;
-  expectedOutput: string | null;
-  initiallyCompleted: boolean;
+export type ProblemStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+
+export type ProblemSubmitResult = {
+  passed: boolean;
+  output: string;
+  code: string;
 };
 
-export function useLessonRunner({
-  lessonId,
-  starterCode,
-  expectedOutput,
-  initiallyCompleted,
-}: Args) {
+type Args = {
+  starterCode: string;
+  expectedOutput: string | null;
+  initialStatus: ProblemStatus;
+  onSubmit?: (result: ProblemSubmitResult) => Promise<void>;
+};
+
+export function useProblemRunner({ starterCode, expectedOutput, initialStatus, onSubmit }: Args) {
   const [code, setCode] = useState(starterCode);
   const [output, setOutput] = useState<RunResult | null>(null);
   const [running, setRunning] = useState(false);
-  const [completed, setCompleted] = useState(initiallyCompleted);
+  const [completed, setCompleted] = useState(initialStatus === "COMPLETED");
 
   async function run() {
     setRunning(true);
@@ -36,19 +38,15 @@ export function useLessonRunner({
         expectedOutput !== null &&
         data.stdout.trim() === expectedOutput.trim();
 
-      if (passed && !completed) {
+      if (passed && !completed && onSubmit) {
         // Optimistic update: flip the badge immediately, roll back if the
-        // server action fails so the UI stays consistent with the DB.
+        // server callback fails so the UI stays consistent with the DB.
         setCompleted(true);
         try {
-          const result = await completeLessonAction({ lessonId });
-          if (result?.serverError || result?.validationErrors) {
-            setCompleted(false);
-            console.error("[useLessonRunner] completeLessonAction failed:", result);
-          }
+          await onSubmit({ passed, output: data.stdout, code });
         } catch (err) {
           setCompleted(false);
-          console.error("[useLessonRunner] completeLessonAction threw:", err);
+          console.error("[useProblemRunner] onSubmit threw:", err);
         }
       }
     } finally {


### PR DESCRIPTION
## Summary

- `LessonClient` を `src/components/problem-solver/ProblemSolver.tsx` へ抽出して 公式 Lesson / UGC Problem の双方で使える共通 Client Component に整理 (`useLessonRunner` → `useProblemRunner`)
- ProblemSolver はヘッダー/フッターの chrome を `headerLeft` / `subtitle` / `headerRight` / `footerLeft` / `footerHint` の ReactNode slot で受け取り、`onSubmit({ passed, output, code })` callback で進捗保存を呼び元に委譲する
- 公式 Lesson ページは `LessonSolver` (Client wrapper) 経由で ProblemSolver を呼び、`completeLessonAction` を onSubmit に bind
- UGC Problem ページに `ProblemSolverClient` を追加し、`completeProblemAction` を onSubmit に bind / `isProblemCompleted` で `initialStatus` を解決
- TODO 文 \"コードエディタは別 issue で実装予定です\" を削除

## Notes

- `git mv` で `LessonClient.tsx` / `useLessonRunner.ts` をリネーム移動しているので、そのファイルの履歴は温存されている
- worker / esbuild-wasm / Monaco の実行ロジックは触っておらず、prop を抽象化したのみ
- 認可は `actionClient` middleware の `requireAuth` 任せ。Action は `problemId` のみ受け取り、`ctx.session.profile.id` (= `ctx.userId`) で書き込むので、別ユーザー ID を投げ込んでも他者の進捗は記録されない
- ProblemProgress の repository / service / action は #71 と前段の作業ですでに整備済み

## Test plan

- [ ] `npm run check` pass
- [ ] `npx tsc --noEmit` pass
- [ ] `npm run build` pass (Next.js 16 typed routes 含む)
- [ ] /learn/[course]/[lesson] で従来通り Run → 期待出力一致 → "クリア済み" バッジ点灯 + LessonProgress upsert (regression なし)
- [ ] /[handle]/[collection]/[problem] で Monaco エディタ表示 / Run / 判定 / "クリア済み" 表示 + ProblemProgress upsert
- [ ] 期待出力一致しない場合は ProblemProgress が書かれない
- [ ] 既に完了済みの問題ページを開くと初期状態で "クリア済み" バッジが出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)