### PR TITLE
fix(ui): 6 件の UX 修正 (Closes #80)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "codelearn",
+  "name": "arcode",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codelearn",
+      "name": "arcode",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/src/app/(protected)/[handle]/[collection]/[problem]/_components/ProblemSolverClient.tsx
+++ b/src/app/(protected)/[handle]/[collection]/[problem]/_components/ProblemSolverClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ArrowLeft, ChevronRight } from "lucide-react";
-import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import { completeProblemAction } from "@/actions/progress";
+import { BackLink } from "@/components/navigation/BackLink";
 import { ProblemSolver } from "@/components/problem-solver/ProblemSolver";
 import { type CollectionLinkable, collectionUrl } from "@/lib/routes";
 
@@ -38,13 +38,9 @@ export function ProblemSolverClient({ collection, problem, initiallyCompleted }:
       }}
       headerLeft={
         <>
-          <Link
-            href={collectionUrl(collection)}
-            className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
-            style={{ color: "var(--text-2)" }}
-          >
-            <ArrowLeft className="size-3.5" aria-hidden="true" /> コレクション
-          </Link>
+          <BackLink fallbackHref={collectionUrl(collection)} className="text-[12px]">
+            コレクション
+          </BackLink>
           <div className="flex items-center gap-1.5 text-[12px]" style={{ color: "var(--text-3)" }}>
             <span>{collection.title}</span>
             <ChevronRight className="size-3" aria-hidden="true" />

--- a/src/app/(protected)/[handle]/[collection]/[problem]/_components/ProblemSolverClient.tsx
+++ b/src/app/(protected)/[handle]/[collection]/[problem]/_components/ProblemSolverClient.tsx
@@ -38,9 +38,7 @@ export function ProblemSolverClient({ collection, problem, initiallyCompleted }:
       }}
       headerLeft={
         <>
-          <BackLink fallbackHref={collectionUrl(collection)} className="text-[12px]">
-            コレクション
-          </BackLink>
+          <BackLink fallbackHref={collectionUrl(collection)} className="text-[12px]" />
           <div className="flex items-center gap-1.5 text-[12px]" style={{ color: "var(--text-3)" }}>
             <span>{collection.title}</span>
             <ChevronRight className="size-3" aria-hidden="true" />

--- a/src/app/(protected)/[handle]/[collection]/page.tsx
+++ b/src/app/(protected)/[handle]/[collection]/page.tsx
@@ -34,9 +34,7 @@ export default async function CollectionPage({ params }: PageProps<"/[handle]/[c
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "960px" }}>
-      <BackLink fallbackHref={profileUrl(handle)} className="mb-4">
-        {handle}
-      </BackLink>
+      <BackLink fallbackHref={profileUrl(handle)} className="mb-4" />
 
       <header className="mb-7">
         <h1 className="m-0 font-bold text-[26px] tracking-tight">{collection.title}</h1>

--- a/src/app/(protected)/[handle]/[collection]/page.tsx
+++ b/src/app/(protected)/[handle]/[collection]/page.tsx
@@ -1,6 +1,7 @@
-import { ArrowLeft, BookText } from "lucide-react";
+import { BookText } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BackLink } from "@/components/navigation/BackLink";
 import { requireAuth } from "@/lib/auth";
 import { NotFoundError } from "@/lib/errors";
 import { problemUrl, profileUrl } from "@/lib/routes";
@@ -33,18 +34,25 @@ export default async function CollectionPage({ params }: PageProps<"/[handle]/[c
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "960px" }}>
-      <Link
-        href={profileUrl(handle)}
-        className="mb-4 inline-flex items-center gap-1 text-[13px]"
-        style={{ color: "var(--text-3)" }}
-      >
-        <ArrowLeft className="size-3.5" aria-hidden="true" /> {handle}
-      </Link>
+      <BackLink fallbackHref={profileUrl(handle)} className="mb-4">
+        {handle}
+      </BackLink>
 
       <header className="mb-7">
         <h1 className="m-0 font-bold text-[26px] tracking-tight">{collection.title}</h1>
-        <div className="mt-1.5 text-[13px]" style={{ color: "var(--text-3)" }}>
-          {author.handle} · 問題 {collection.problems.length}
+        <div
+          className="mt-1.5 inline-flex items-center gap-1.5 text-[13px]"
+          style={{ color: "var(--text-3)" }}
+        >
+          <Link
+            href={profileUrl(author.handle)}
+            className="transition hover:underline"
+            style={{ color: "var(--text-2)" }}
+          >
+            {author.handle}
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span>問題数 {collection.problems.length}</span>
         </div>
         <p
           className="mt-3 max-w-prose whitespace-pre-wrap text-[14px]"

--- a/src/app/(protected)/[handle]/_components/MyCollectionsSection.tsx
+++ b/src/app/(protected)/[handle]/_components/MyCollectionsSection.tsx
@@ -21,16 +21,9 @@ export function MyCollectionsSection({ author, collections, isOwner }: MyCollect
   return (
     <section>
       <div className="mb-4 flex items-baseline justify-between">
-        <div>
-          <h2 className="m-0 font-semibold text-[18px] tracking-tight">
-            {isOwner ? "作成したコレクション" : "公開しているコレクション"}
-          </h2>
-          <span className="text-xs" style={{ color: "var(--text-3)" }}>
-            {isOwner
-              ? "あなたが作者として公開 / 管理しているコレクション"
-              : `${author.handle} が公開しているコレクション`}
-          </span>
-        </div>
+        <h2 className="m-0 font-semibold text-[18px] tracking-tight">
+          {isOwner ? "作成したコレクション" : "公開しているコレクション"}
+        </h2>
         {isOwner ? (
           <Link href="/dashboard" className="text-[13px]" style={{ color: "var(--accent-solid)" }}>
             管理する →

--- a/src/app/(protected)/[handle]/bookmarks/_components/BookmarkCollectionList.tsx
+++ b/src/app/(protected)/[handle]/bookmarks/_components/BookmarkCollectionList.tsx
@@ -1,14 +1,15 @@
-import Link from "next/link";
-import { coverFor, glyphFor } from "@/app/(protected)/_components/courseCover";
-import { collectionUrl } from "@/lib/routes";
-import { cn } from "@/lib/utils";
+import { CollectionCard } from "@/app/(protected)/_components/CollectionCard";
 import type { CollectionBookmarkWithCollection } from "@/repositories";
 
 type BookmarkCollectionListProps = {
   collections: CollectionBookmarkWithCollection[];
+  completedProblemIds: Set<string>;
 };
 
-export function BookmarkCollectionList({ collections }: BookmarkCollectionListProps) {
+export function BookmarkCollectionList({
+  collections,
+  completedProblemIds,
+}: BookmarkCollectionListProps) {
   if (collections.length === 0) return null;
   return (
     <section className="mb-9">
@@ -22,52 +23,18 @@ export function BookmarkCollectionList({ collections }: BookmarkCollectionListPr
       </div>
       <ul
         className="grid gap-4"
-        style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
+        style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
       >
         {collections.map((b, idx) => (
           <li key={b.id}>
-            <CollectionBookmarkCard collection={b.collection} index={idx} />
+            <CollectionCard
+              collection={b.collection}
+              index={idx}
+              completedIds={completedProblemIds}
+            />
           </li>
         ))}
       </ul>
     </section>
-  );
-}
-
-function CollectionBookmarkCard({
-  collection,
-  index,
-}: {
-  collection: CollectionBookmarkWithCollection["collection"];
-  index: number;
-}) {
-  return (
-    <Link
-      href={collectionUrl(collection)}
-      className={cn(
-        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
-        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
-      )}
-      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-    >
-      <div className={cn("cm-cover", coverFor(index))}>
-        <span className="cm-cover-glyph" aria-hidden="true">
-          {glyphFor(collection.title)}
-        </span>
-      </div>
-      <div className="flex flex-1 flex-col gap-2 p-4">
-        <h3
-          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
-          style={{ color: "var(--text-1)" }}
-        >
-          {collection.title}
-        </h3>
-        {collection.description ? (
-          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
-            {collection.description}
-          </p>
-        ) : null}
-      </div>
-    </Link>
   );
 }

--- a/src/app/(protected)/[handle]/bookmarks/_components/BookmarkCourseList.tsx
+++ b/src/app/(protected)/[handle]/bookmarks/_components/BookmarkCourseList.tsx
@@ -1,14 +1,12 @@
-import Link from "next/link";
-import { coverFor, glyphFor } from "@/app/(protected)/_components/courseCover";
-import { learnUrl } from "@/lib/routes";
-import { cn } from "@/lib/utils";
+import { CourseCard } from "@/app/(protected)/_components/CourseCard";
 import type { CourseBookmarkWithCourse } from "@/repositories";
 
 type BookmarkCourseListProps = {
   courses: CourseBookmarkWithCourse[];
+  completedLessonIds: Set<string>;
 };
 
-export function BookmarkCourseList({ courses }: BookmarkCourseListProps) {
+export function BookmarkCourseList({ courses, completedLessonIds }: BookmarkCourseListProps) {
   if (courses.length === 0) return null;
   return (
     <section className="mb-9">
@@ -22,52 +20,14 @@ export function BookmarkCourseList({ courses }: BookmarkCourseListProps) {
       </div>
       <ul
         className="grid gap-4"
-        style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
+        style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
       >
         {courses.map((b, idx) => (
           <li key={b.id}>
-            <CourseBookmarkCard course={b.course} index={idx} />
+            <CourseCard course={b.course} index={idx} completedIds={completedLessonIds} />
           </li>
         ))}
       </ul>
     </section>
-  );
-}
-
-function CourseBookmarkCard({
-  course,
-  index,
-}: {
-  course: CourseBookmarkWithCourse["course"];
-  index: number;
-}) {
-  return (
-    <Link
-      href={learnUrl(course)}
-      className={cn(
-        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
-        "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
-      )}
-      style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-    >
-      <div className={cn("cm-cover", coverFor(index))}>
-        <span className="cm-cover-glyph" aria-hidden="true">
-          {glyphFor(course.title)}
-        </span>
-      </div>
-      <div className="flex flex-1 flex-col gap-2 p-4">
-        <h3
-          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
-          style={{ color: "var(--text-1)" }}
-        >
-          {course.title}
-        </h3>
-        {course.description ? (
-          <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>
-            {course.description}
-          </p>
-        ) : null}
-      </div>
-    </Link>
   );
 }

--- a/src/app/(protected)/[handle]/bookmarks/page.tsx
+++ b/src/app/(protected)/[handle]/bookmarks/page.tsx
@@ -4,6 +4,10 @@ import { notFound } from "next/navigation";
 import { requireAuth } from "@/lib/auth";
 import { getUserBookmarks } from "@/services/bookmarkService";
 import { getProfileByHandle } from "@/services/profileService";
+import {
+  getCompletedLessonIdsByUser,
+  getCompletedProblemIdsByUser,
+} from "@/services/progressService";
 import { BookmarkCollectionList } from "./_components/BookmarkCollectionList";
 import { BookmarkCourseList } from "./_components/BookmarkCourseList";
 import { BookmarkLessonList } from "./_components/BookmarkLessonList";
@@ -33,7 +37,14 @@ export default async function BookmarksPage({
   // The bookmark service queries WHERE userId = viewedProfile.id, so even if
   // a future change loosened the isOwner gate above, the data fetch itself
   // would still be scoped to one user — Layer C defence in depth.
-  const { courses, lessons, collections, problems } = await getUserBookmarks(viewedProfile.id);
+  const [bookmarks, completedLessonIds, completedProblemIds] = await Promise.all([
+    getUserBookmarks(viewedProfile.id),
+    getCompletedLessonIdsByUser(viewedProfile.id),
+    getCompletedProblemIdsByUser(viewedProfile.id),
+  ]);
+  const { courses, lessons, collections, problems } = bookmarks;
+  const completedLessonIdSet = new Set(completedLessonIds);
+  const completedProblemIdSet = new Set(completedProblemIds);
   const officialCount = courses.length + lessons.length;
   const communityCount = collections.length + problems.length;
   const total = officialCount + communityCount;
@@ -77,7 +88,7 @@ export default async function BookmarksPage({
               <EmptyTab message="公式コンテンツのお気に入りはまだありません。" />
             ) : (
               <>
-                <BookmarkCourseList courses={courses} />
+                <BookmarkCourseList courses={courses} completedLessonIds={completedLessonIdSet} />
                 <BookmarkLessonList lessons={lessons} />
               </>
             )
@@ -85,7 +96,10 @@ export default async function BookmarksPage({
             <EmptyTab message="コミュニティのお気に入りはまだありません。" />
           ) : (
             <>
-              <BookmarkCollectionList collections={collections} />
+              <BookmarkCollectionList
+                collections={collections}
+                completedProblemIds={completedProblemIdSet}
+              />
               <BookmarkProblemList problems={problems} />
             </>
           )}

--- a/src/app/(protected)/_components/TopBarSwitcher.tsx
+++ b/src/app/(protected)/_components/TopBarSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSelectedLayoutSegments } from "next/navigation";
+import { RESERVED_HANDLES } from "@/lib/reservedNames";
 import { TopBar } from "./TopBar";
 
 type Props = {
@@ -15,11 +16,13 @@ export function TopBarSwitcher(props: Props) {
   // pages run their own full-bleed header (split editor / problem chrome) and
   // suppress the global TopBar so it doesn't double-render above the editor.
   // - Official lesson : ["learn", "<course>", "<lesson>"]   (3 segments)
-  // - UGC problem     : ["<handle>", "<collection>", "<problem>"] (3 segments)
-  // The UGC problem stub renders inline content for now, so we only suppress
-  // the bar for the official lesson route until UGC gets the same treatment.
+  // - UGC problem     : ["<handle>", "<collection>", "<problem>"] (3 segments,
+  //   segment[0] must NOT be a reserved name — that is what makes it a handle)
   const segments = useSelectedLayoutSegments();
-  const isFullBleed = segments[0] === "learn" && segments.length === 3;
+  const first = segments[0];
+  const isFullBleed =
+    segments.length === 3 &&
+    (first === "learn" || (typeof first === "string" && !RESERVED_HANDLES.has(first)));
   if (isFullBleed) return null;
   return <TopBar {...props} />;
 }

--- a/src/app/(protected)/learn/[course]/[lesson]/_components/LessonSolver.tsx
+++ b/src/app/(protected)/learn/[course]/[lesson]/_components/LessonSolver.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, ArrowRight, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { completeLessonAction } from "@/actions/progress";
 import { BookmarkButton } from "@/components/bookmarks/BookmarkButton";
+import { BackLink } from "@/components/navigation/BackLink";
 import { ProblemSolver } from "@/components/problem-solver/ProblemSolver";
 import { type CourseLinkable, learnUrl, lessonUrl } from "@/lib/routes";
 
@@ -51,13 +52,9 @@ export function LessonSolver({
       }}
       headerLeft={
         <>
-          <Link
-            href={learnUrl(course)}
-            className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1.5 text-[12px]"
-            style={{ color: "var(--text-2)" }}
-          >
-            <ArrowLeft className="size-3.5" aria-hidden="true" /> コース
-          </Link>
+          <BackLink fallbackHref={learnUrl(course)} className="text-[12px]">
+            コース
+          </BackLink>
           <div className="flex items-center gap-1.5 text-[12px]" style={{ color: "var(--text-3)" }}>
             <span>{courseTitle}</span>
             <ChevronRight className="size-3" aria-hidden="true" />

--- a/src/app/(protected)/learn/[course]/[lesson]/_components/LessonSolver.tsx
+++ b/src/app/(protected)/learn/[course]/[lesson]/_components/LessonSolver.tsx
@@ -52,9 +52,7 @@ export function LessonSolver({
       }}
       headerLeft={
         <>
-          <BackLink fallbackHref={learnUrl(course)} className="text-[12px]">
-            コース
-          </BackLink>
+          <BackLink fallbackHref={learnUrl(course)} className="text-[12px]" />
           <div className="flex items-center gap-1.5 text-[12px]" style={{ color: "var(--text-3)" }}>
             <span>{courseTitle}</span>
             <ChevronRight className="size-3" aria-hidden="true" />

--- a/src/app/(protected)/learn/[course]/page.tsx
+++ b/src/app/(protected)/learn/[course]/page.tsx
@@ -1,6 +1,5 @@
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BackLink } from "@/components/navigation/BackLink";
 import { requireAuth } from "@/lib/auth";
 import { NotFoundError } from "@/lib/errors";
 import { isCourseBookmarked } from "@/services/bookmarkService";
@@ -37,13 +36,9 @@ export default async function CoursePage({ params }: PageProps<"/learn/[course]"
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
-      <Link
-        href="/learn"
-        className="mb-4 inline-flex items-center gap-1 text-[13px]"
-        style={{ color: "var(--text-3)" }}
-      >
-        <ArrowLeft className="size-3.5" aria-hidden="true" /> 公式コース一覧
-      </Link>
+      <BackLink fallbackHref="/learn" className="mb-4">
+        公式コース一覧
+      </BackLink>
 
       <CourseHero course={course} done={done} total={total} pct={pct} bookmarked={bookmarked} />
 

--- a/src/app/(protected)/learn/[course]/page.tsx
+++ b/src/app/(protected)/learn/[course]/page.tsx
@@ -36,9 +36,7 @@ export default async function CoursePage({ params }: PageProps<"/learn/[course]"
 
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "1280px" }}>
-      <BackLink fallbackHref="/learn" className="mb-4">
-        公式コース一覧
-      </BackLink>
+      <BackLink fallbackHref="/learn" className="mb-4" />
 
       <CourseHero course={course} done={done} total={total} pct={pct} bookmarked={bookmarked} />
 

--- a/src/app/(protected)/settings/profile/page.tsx
+++ b/src/app/(protected)/settings/profile/page.tsx
@@ -1,5 +1,4 @@
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
+import { BackLink } from "@/components/navigation/BackLink";
 import { requireAuth } from "@/lib/auth";
 import { profileUrl } from "@/lib/routes";
 import { ProfileEditForm } from "./_components/ProfileEditForm";
@@ -13,14 +12,7 @@ export default async function ProfileEditPage() {
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "720px" }}>
       <div className="mb-6">
-        <Link
-          href={profileUrl(profile.handle)}
-          className="inline-flex items-center gap-1.5 text-[13px]"
-          style={{ color: "var(--text-3)" }}
-        >
-          <ArrowLeft className="size-3.5" aria-hidden="true" />
-          プロフィールに戻る
-        </Link>
+        <BackLink fallbackHref={profileUrl(profile.handle)}>プロフィールに戻る</BackLink>
       </div>
 
       <header className="mb-7">

--- a/src/app/(protected)/settings/profile/page.tsx
+++ b/src/app/(protected)/settings/profile/page.tsx
@@ -12,7 +12,7 @@ export default async function ProfileEditPage() {
   return (
     <div className="cm-route-enter mx-auto w-full px-6 pt-8 pb-20" style={{ maxWidth: "720px" }}>
       <div className="mb-6">
-        <BackLink fallbackHref={profileUrl(profile.handle)}>プロフィールに戻る</BackLink>
+        <BackLink fallbackHref={profileUrl(profile.handle)} />
       </div>
 
       <header className="mb-7">

--- a/src/components/content/ContentCard.tsx
+++ b/src/components/content/ContentCard.tsx
@@ -22,9 +22,11 @@ export type ContentCardProps = {
 
 /**
  * Shared card primitive for /learn (CourseCard) and / (CollectionCard).
- * The card itself is *not* an anchor so children like <HandleLink> can be
- * real anchors without nesting (which is invalid HTML). The destination
- * link is placed on the cover + title only.
+ * Uses the "stretched link" pattern: the title is the canonical anchor and
+ * its `::before` pseudo-element covers the whole card so the entire surface
+ * is clickable. Nested interactive children (HandleLink, BookmarkButton…)
+ * sit on a higher stacking context (`relative z-10`) so they remain
+ * independently clickable instead of nesting inside another anchor.
  */
 export function ContentCard({
   href,
@@ -43,26 +45,35 @@ export function ContentCard({
   return (
     <article
       className={cn(
-        "group flex h-full flex-col overflow-hidden rounded-[14px] transition",
+        "group relative flex h-full flex-col overflow-hidden rounded-[14px] transition",
         "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
       )}
       style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
     >
-      <Link href={href} className="relative block">
+      <div className="relative block">
         {cover}
         {topBadge ? <span className="absolute top-2.5 right-2.5 z-10">{topBadge}</span> : null}
-      </Link>
+      </div>
       <div className="flex flex-1 flex-col gap-2.5 p-4">
-        <Link href={href} className="block">
-          <h3
-            className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight transition group-hover:opacity-90"
-            style={{ color: "var(--text-1)" }}
+        <h3
+          className="m-0 line-clamp-2 font-semibold text-[15px] leading-snug tracking-tight"
+          style={{ color: "var(--text-1)" }}
+        >
+          <Link
+            href={href}
+            className={cn(
+              "block transition group-hover:opacity-90",
+              "before:absolute before:inset-0 before:z-0 before:content-['']",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-solid)] focus-visible:rounded-[14px]",
+            )}
           >
             {title}
-          </h3>
-        </Link>
+          </Link>
+        </h3>
 
-        {byline ? <div className="flex items-center gap-1.5">{byline}</div> : null}
+        {byline ? (
+          <div className="relative z-10 flex w-fit items-center gap-1.5">{byline}</div>
+        ) : null}
 
         {description ? (
           <p className="m-0 line-clamp-2 text-[12.5px]" style={{ color: "var(--text-3)" }}>

--- a/src/components/content/ContentCard.tsx
+++ b/src/components/content/ContentCard.tsx
@@ -47,6 +47,10 @@ export function ContentCard({
       className={cn(
         "group relative flex h-full flex-col overflow-hidden rounded-[14px] transition",
         "hover:-translate-y-0.5 hover:border-[color:var(--line-3)]",
+        // The clickable area is the inner Link's stretched ::before, so keyboard focus
+        // lives on the Link. Mirror that focus on the article so the ring outlines the
+        // whole card rather than just the title text bounding box.
+        "focus-within:ring-2 focus-within:ring-[var(--accent-solid)] focus-within:ring-offset-2 focus-within:ring-offset-[var(--bg-0)]",
       )}
       style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
     >
@@ -64,7 +68,7 @@ export function ContentCard({
             className={cn(
               "block transition group-hover:opacity-90",
               "before:absolute before:inset-0 before:z-0 before:content-['']",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-solid)] focus-visible:rounded-[14px]",
+              "focus-visible:outline-none",
             )}
           >
             {title}

--- a/src/components/navigation/BackLink.tsx
+++ b/src/components/navigation/BackLink.tsx
@@ -6,14 +6,19 @@ import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 type Props = {
-  /** Visible label after the arrow icon. */
-  children: ReactNode;
+  /**
+   * Visible label after the arrow icon. Defaults to "もどる" so every back
+   * button across the app reads consistently — page-specific labels (e.g.
+   * a parent page's title) tend to confuse users who associate the button
+   * with what is on the previous screen, not where it is in the URL tree.
+   */
+  children?: ReactNode;
   /** Pushed instead of router.back() when the user has no history (e.g. opened in a new tab). */
   fallbackHref?: string;
   className?: string;
 };
 
-export function BackLink({ children, fallbackHref = "/", className }: Props) {
+export function BackLink({ children = "もどる", fallbackHref = "/", className }: Props) {
   const router = useRouter();
 
   const onClick = () => {

--- a/src/components/navigation/BackLink.tsx
+++ b/src/components/navigation/BackLink.tsx
@@ -18,7 +18,7 @@ type Props = {
   className?: string;
 };
 
-export function BackLink({ children = "もどる", fallbackHref = "/", className }: Props) {
+export function BackLink({ children = "戻る", fallbackHref = "/", className }: Props) {
   const router = useRouter();
 
   const onClick = () => {

--- a/src/components/navigation/BackLink.tsx
+++ b/src/components/navigation/BackLink.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  /** Visible label after the arrow icon. */
+  children: ReactNode;
+  /** Pushed instead of router.back() when the user has no history (e.g. opened in a new tab). */
+  fallbackHref?: string;
+  className?: string;
+};
+
+export function BackLink({ children, fallbackHref = "/", className }: Props) {
+  const router = useRouter();
+
+  const onClick = () => {
+    // window.history.length is 1 when the tab opened directly to this page.
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(fallbackHref);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1 text-[13px] transition hover:underline",
+        className,
+      )}
+      style={{ color: "var(--text-3)" }}
+    >
+      <ArrowLeft className="size-3.5" aria-hidden="true" /> {children}
+    </button>
+  );
+}

--- a/src/components/problem-solver/ProblemSolver.tsx
+++ b/src/components/problem-solver/ProblemSolver.tsx
@@ -174,22 +174,23 @@ export function ProblemSolver({
       {/*
         md+ : horizontal split — left pane stacks problem above editor (with the
         Run button on top of the editor), right pane shows execution results.
-        < md : single scrollable column where each section keeps its own
-        bounded height so the Run button stays inside the viewport.
+        < md : the body itself becomes the scroll container so the three panes
+        can stack with relaxed min-heights without being clipped, and a
+        floating Run button is rendered below for one-tap reach.
       */}
       <div
         ref={splitRef}
-        className="flex min-h-0 flex-1 flex-col overflow-hidden md:grid"
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto md:grid md:overflow-hidden"
         style={splitStyle}
       >
         {/* LEFT pane: problem (top) + editor with Run toolbar (bottom) */}
         <div
-          className="flex min-h-0 flex-col overflow-hidden border-b md:border-b-0"
+          className="flex min-h-0 flex-col overflow-visible border-b md:overflow-hidden md:border-b-0"
           style={{ borderColor: "var(--line-1)", minWidth: 0 }}
         >
           {/* Problem statement */}
           <div
-            className="flex min-h-[180px] flex-[1.1] flex-col overflow-hidden border-b md:flex-1"
+            className="flex min-h-[140px] flex-[1.1] flex-col overflow-visible border-b md:min-h-[180px] md:flex-1 md:overflow-hidden"
             style={{ borderColor: "var(--line-1)" }}
           >
             <div
@@ -203,7 +204,7 @@ export function ProblemSolver({
                 <FileText className="size-3.5" aria-hidden="true" /> 問題
               </div>
             </div>
-            <div className="flex-1 overflow-auto px-6 py-5">
+            <div className="flex-1 overflow-visible px-6 py-5 md:overflow-auto">
               <div className="mx-auto max-w-[720px]" style={{ color: "var(--text-2)" }}>
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
@@ -335,7 +336,7 @@ export function ProblemSolver({
 
           {/* Editor */}
           <div
-            className="flex min-h-[260px] flex-[1.4] flex-col overflow-hidden md:flex-1"
+            className="flex min-h-[220px] flex-[1.4] flex-col overflow-hidden md:min-h-[260px] md:flex-1"
             style={{ background: "var(--bg-code)" }}
           >
             <div
@@ -428,7 +429,7 @@ export function ProblemSolver({
 
         {/* RIGHT pane: results */}
         <div
-          className="flex min-h-[180px] flex-[0.9] flex-col overflow-hidden md:flex-1"
+          className="flex min-h-[140px] flex-[0.9] flex-col overflow-visible md:min-h-[180px] md:flex-1 md:overflow-hidden"
           style={{ background: "var(--bg-0)", minWidth: 0 }}
         >
           <div
@@ -448,13 +449,30 @@ export function ProblemSolver({
             ) : null}
           </div>
           <div
-            className="flex-1 overflow-auto p-4 font-mono text-[12px]"
+            className="flex-1 overflow-visible p-4 font-mono text-[12px] md:overflow-auto"
             style={{ color: "var(--text-1)" }}
           >
             <ResultBody output={output} expected={expectedOutput} passed={passed} />
           </div>
         </div>
       </div>
+
+      {/* Mobile-only floating Run button — keeps the primary action one tap away
+          regardless of how far the user has scrolled the body on small screens. */}
+      <button
+        type="button"
+        disabled={running}
+        onClick={run}
+        aria-label="コードを実行"
+        className={cn(
+          "fixed right-4 bottom-16 z-30 inline-flex items-center gap-1.5 rounded-full px-5 py-3 font-semibold text-[13px] shadow-lg transition md:hidden",
+          running ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
+        )}
+        style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
+      >
+        <Play className="size-4" aria-hidden="true" />
+        {running ? "実行中…" : "実行"}
+      </button>
 
       {/* Bottom bar — navigation and hint only; the Run button now lives inside the editor toolbar */}
       <footer

--- a/src/components/problem-solver/ProblemSolver.tsx
+++ b/src/components/problem-solver/ProblemSolver.tsx
@@ -149,7 +149,7 @@ export function ProblemSolver({
 
   return (
     <div
-      className="flex h-screen flex-col overflow-hidden"
+      className="flex h-dvh flex-col overflow-hidden"
       style={{ background: "var(--bg-0)", color: "var(--text-1)" }}
     >
       {/* Problem top bar */}
@@ -351,6 +351,14 @@ export function ProblemSolver({
           aria-orientation="vertical"
           aria-label="問題ペインとエディタペインの横幅を調整"
           aria-valuemin={MIN_LEFT_PX}
+          aria-valuemax={
+            splitRef.current
+              ? Math.max(
+                  MIN_LEFT_PX,
+                  splitRef.current.getBoundingClientRect().width * MAX_LEFT_RATIO,
+                )
+              : undefined
+          }
           aria-valuenow={leftWidth ?? undefined}
           tabIndex={0}
           onMouseDown={onResizerMouseDown}

--- a/src/components/problem-solver/ProblemSolver.tsx
+++ b/src/components/problem-solver/ProblemSolver.tsx
@@ -378,10 +378,7 @@ export function ProblemSolver({
             className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
             style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
           >
-            <div
-              className="flex items-center gap-2 text-[12px]"
-              style={{ color: "var(--text-3)" }}
-            >
+            <div className="flex items-center gap-2 text-[12px]" style={{ color: "var(--text-3)" }}>
               <span
                 className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
                 style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}

--- a/src/components/problem-solver/ProblemSolver.tsx
+++ b/src/components/problem-solver/ProblemSolver.tsx
@@ -130,20 +130,19 @@ export function ProblemSolver({
 
   const splitStyle: CSSProperties =
     leftWidth !== null
-      ? { gridTemplateColumns: `${leftWidth}px 6px minmax(0,1fr)`, flex: 1 }
+      ? { gridTemplateColumns: `${leftWidth}px 6px minmax(0,1fr)` }
       : {
-          gridTemplateColumns: "minmax(280px, 1fr) 6px minmax(420px, 1.2fr)",
-          flex: 1,
+          gridTemplateColumns: "minmax(280px, 1.2fr) 6px minmax(360px, 1fr)",
         };
 
   return (
     <div
-      className="flex h-screen flex-col"
+      className="flex h-screen flex-col overflow-hidden"
       style={{ background: "var(--bg-0)", color: "var(--text-1)" }}
     >
       {/* Problem top bar */}
       <header
-        className="grid items-center gap-4 border-b px-5 py-2.5"
+        className="grid flex-shrink-0 items-center gap-4 border-b px-5 py-2.5"
         style={{
           gridTemplateColumns: "1fr auto 1fr",
           borderColor: "var(--line-1)",
@@ -172,194 +171,175 @@ export function ProblemSolver({
         </div>
       </header>
 
-      {/* Split pane */}
-      <div ref={splitRef} className="grid overflow-hidden" style={splitStyle}>
-        {/* LEFT: problem statement */}
+      {/*
+        md+ : horizontal split — left pane stacks problem above editor (with the
+        Run button on top of the editor), right pane shows execution results.
+        < md : single scrollable column where each section keeps its own
+        bounded height so the Run button stays inside the viewport.
+      */}
+      <div
+        ref={splitRef}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden md:grid"
+        style={splitStyle}
+      >
+        {/* LEFT pane: problem (top) + editor with Run toolbar (bottom) */}
         <div
-          className="flex flex-col overflow-hidden"
+          className="flex min-h-0 flex-col overflow-hidden border-b md:border-b-0"
           style={{ borderColor: "var(--line-1)", minWidth: 0 }}
         >
+          {/* Problem statement */}
           <div
-            className="flex flex-shrink-0 items-center gap-0.5 border-b px-3 py-1.5"
-            style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
+            className="flex min-h-[180px] flex-[1.1] flex-col overflow-hidden border-b md:flex-1"
+            style={{ borderColor: "var(--line-1)" }}
           >
             <div
-              className="inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1.5 font-medium text-[12px]"
-              style={{
-                color: "var(--text-1)",
-                background: "var(--bg-2)",
-              }}
+              className="flex flex-shrink-0 items-center gap-0.5 border-b px-3 py-1.5"
+              style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
             >
-              <FileText className="size-3.5" aria-hidden="true" /> 問題
+              <div
+                className="inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1.5 font-medium text-[12px]"
+                style={{ color: "var(--text-1)", background: "var(--bg-2)" }}
+              >
+                <FileText className="size-3.5" aria-hidden="true" /> 問題
+              </div>
             </div>
-          </div>
-          <div className="flex-1 overflow-auto px-6 py-5">
-            <div className="mx-auto max-w-[720px]" style={{ color: "var(--text-2)" }}>
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={{
-                  h1: ({ children }) => (
-                    <h1
-                      className="mt-1 mb-4 font-bold text-[22px] tracking-tight"
-                      style={{ color: "var(--text-1)" }}
-                    >
-                      {children}
-                    </h1>
-                  ),
-                  h2: ({ children }) => (
+            <div className="flex-1 overflow-auto px-6 py-5">
+              <div className="mx-auto max-w-[720px]" style={{ color: "var(--text-2)" }}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    h1: ({ children }) => (
+                      <h1
+                        className="mt-1 mb-4 font-bold text-[22px] tracking-tight"
+                        style={{ color: "var(--text-1)" }}
+                      >
+                        {children}
+                      </h1>
+                    ),
+                    h2: ({ children }) => (
+                      <h2
+                        className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
+                        style={{ color: "var(--text-1)" }}
+                      >
+                        {children}
+                      </h2>
+                    ),
+                    h3: ({ children }) => (
+                      <h3
+                        className="mt-5 mb-2 font-semibold text-[14px]"
+                        style={{ color: "var(--text-1)" }}
+                      >
+                        {children}
+                      </h3>
+                    ),
+                    p: ({ children }) => <p className="mb-3 leading-7 text-[13.5px]">{children}</p>,
+                    code: ({ className, children, ...rest }) => {
+                      // react-markdown v10+ no longer passes an `inline` prop. Treat a single
+                      // text node without a language class as inline; anything structural
+                      // (multi-line content, nested nodes) is a fenced block.
+                      const isInline =
+                        !className && typeof children === "string" && !children.includes("\n");
+                      return isInline ? (
+                        <code
+                          className="rounded px-1.5 py-0.5 font-mono text-[0.9em]"
+                          style={{
+                            background: "var(--bg-2)",
+                            color: "var(--accent-solid)",
+                            border: "1px solid var(--line-1)",
+                          }}
+                        >
+                          {children}
+                        </code>
+                      ) : (
+                        <code className={className} {...rest}>
+                          {children}
+                        </code>
+                      );
+                    },
+                    pre: ({ children }) => (
+                      <pre
+                        className="mb-4 overflow-x-auto rounded-[10px] p-3 font-mono text-[12.5px] leading-relaxed"
+                        style={{
+                          background: "var(--bg-code)",
+                          border: "1px solid var(--line-1)",
+                          color: "var(--text-1)",
+                        }}
+                      >
+                        {children}
+                      </pre>
+                    ),
+                    ul: ({ children }) => (
+                      <ul className="mb-3 list-disc space-y-1 pl-5">{children}</ul>
+                    ),
+                    ol: ({ children }) => (
+                      <ol className="mb-3 list-decimal space-y-1 pl-5">{children}</ol>
+                    ),
+                    a: ({ href, children }) => (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline"
+                        style={{ color: "var(--accent-solid)" }}
+                      >
+                        {children}
+                      </a>
+                    ),
+                    strong: ({ children }) => (
+                      <strong className="font-semibold" style={{ color: "var(--text-1)" }}>
+                        {children}
+                      </strong>
+                    ),
+                  }}
+                >
+                  {contentMd}
+                </ReactMarkdown>
+
+                {expectedOutput ? (
+                  <section className="mt-6">
                     <h2
                       className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
                       style={{ color: "var(--text-1)" }}
                     >
-                      {children}
+                      期待される出力
                     </h2>
-                  ),
-                  h3: ({ children }) => (
-                    <h3
-                      className="mt-5 mb-2 font-semibold text-[14px]"
-                      style={{ color: "var(--text-1)" }}
+                    <div
+                      className="overflow-hidden rounded-[10px]"
+                      style={{
+                        background: "var(--bg-1)",
+                        border: "1px solid var(--line-1)",
+                      }}
                     >
-                      {children}
-                    </h3>
-                  ),
-                  p: ({ children }) => <p className="mb-3 leading-7 text-[13.5px]">{children}</p>,
-                  code: ({ className, children, ...rest }) => {
-                    // react-markdown v10+ no longer passes an `inline` prop. Treat a single
-                    // text node without a language class as inline; anything structural
-                    // (multi-line content, nested nodes) is a fenced block.
-                    const isInline =
-                      !className && typeof children === "string" && !children.includes("\n");
-                    return isInline ? (
-                      <code
-                        className="rounded px-1.5 py-0.5 font-mono text-[0.9em]"
+                      <div
+                        className="border-b px-3 py-2 font-mono text-[11px]"
                         style={{
+                          borderColor: "var(--line-1)",
                           background: "var(--bg-2)",
-                          color: "var(--accent-solid)",
-                          border: "1px solid var(--line-1)",
+                          color: "var(--text-3)",
                         }}
                       >
-                        {children}
-                      </code>
-                    ) : (
-                      <code className={className} {...rest}>
-                        {children}
-                      </code>
-                    );
-                  },
-                  pre: ({ children }) => (
-                    <pre
-                      className="mb-4 overflow-x-auto rounded-[10px] p-3 font-mono text-[12.5px] leading-relaxed"
-                      style={{
-                        background: "var(--bg-code)",
-                        border: "1px solid var(--line-1)",
-                        color: "var(--text-1)",
-                      }}
-                    >
-                      {children}
-                    </pre>
-                  ),
-                  ul: ({ children }) => (
-                    <ul className="mb-3 list-disc space-y-1 pl-5">{children}</ul>
-                  ),
-                  ol: ({ children }) => (
-                    <ol className="mb-3 list-decimal space-y-1 pl-5">{children}</ol>
-                  ),
-                  a: ({ href, children }) => (
-                    <a
-                      href={href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline"
-                      style={{ color: "var(--accent-solid)" }}
-                    >
-                      {children}
-                    </a>
-                  ),
-                  strong: ({ children }) => (
-                    <strong className="font-semibold" style={{ color: "var(--text-1)" }}>
-                      {children}
-                    </strong>
-                  ),
-                }}
-              >
-                {contentMd}
-              </ReactMarkdown>
-
-              {expectedOutput ? (
-                <section className="mt-6">
-                  <h2
-                    className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
-                    style={{ color: "var(--text-1)" }}
-                  >
-                    期待される出力
-                  </h2>
-                  <div
-                    className="overflow-hidden rounded-[10px]"
-                    style={{
-                      background: "var(--bg-1)",
-                      border: "1px solid var(--line-1)",
-                    }}
-                  >
-                    <div
-                      className="border-b px-3 py-2 font-mono text-[11px]"
-                      style={{
-                        borderColor: "var(--line-1)",
-                        background: "var(--bg-2)",
-                        color: "var(--text-3)",
-                      }}
-                    >
-                      Expected stdout
+                        Expected stdout
+                      </div>
+                      <pre
+                        className="m-0 p-3 font-mono text-[12.5px] leading-relaxed"
+                        style={{ background: "var(--bg-code)", color: "var(--text-1)" }}
+                      >
+                        {expectedOutput}
+                      </pre>
                     </div>
-                    <pre
-                      className="m-0 p-3 font-mono text-[12.5px] leading-relaxed"
-                      style={{ background: "var(--bg-code)", color: "var(--text-1)" }}
-                    >
-                      {expectedOutput}
-                    </pre>
-                  </div>
-                </section>
-              ) : null}
+                  </section>
+                ) : null}
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Resizer */}
-        {/* biome-ignore lint/a11y/useSemanticElements: ARIA separator role is required for split-pane resize handles; <hr> cannot host interactive behavior */}
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="問題とエディターの横幅を調整"
-          aria-valuemin={MIN_LEFT_PX}
-          aria-valuenow={leftWidth ?? undefined}
-          tabIndex={0}
-          onMouseDown={onResizerMouseDown}
-          onKeyDown={onResizerKeyDown}
-          className="relative flex cursor-col-resize touch-none items-center justify-center border-r border-l transition-colors hover:bg-[var(--bg-2)] focus-visible:bg-[var(--bg-2)]"
-          style={{
-            borderColor: "var(--line-1)",
-            background: "var(--bg-0)",
-          }}
-        >
-          <span
-            aria-hidden="true"
-            className="h-8 w-0.5 rounded"
-            style={{ background: "var(--line-2)" }}
-          />
-        </div>
-
-        {/* RIGHT: editor + results */}
-        <div
-          className="grid overflow-hidden"
-          style={{
-            gridTemplateRows: "1fr 240px",
-            background: "var(--bg-code)",
-            minWidth: 0,
-          }}
-        >
           {/* Editor */}
-          <div className="flex flex-col overflow-hidden">
+          <div
+            className="flex min-h-[260px] flex-[1.4] flex-col overflow-hidden md:flex-1"
+            style={{ background: "var(--bg-code)" }}
+          >
             <div
-              className="flex flex-shrink-0 items-center justify-between border-b px-2.5 py-1.5"
+              className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
               style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
             >
               <div
@@ -374,7 +354,7 @@ export function ProblemSolver({
                 </span>
                 <span className="font-mono">main.ts</span>
               </div>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-2">
                 <button
                   type="button"
                   onClick={reset}
@@ -383,9 +363,23 @@ export function ProblemSolver({
                 >
                   <RotateCcw className="size-3" aria-hidden="true" /> リセット
                 </button>
+                <button
+                  type="button"
+                  disabled={running}
+                  onClick={run}
+                  aria-label="コードを実行"
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-[8px] px-3.5 py-1.5 font-semibold text-[12.5px] transition",
+                    running ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
+                  )}
+                  style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
+                >
+                  <Play className="size-3.5" aria-hidden="true" />
+                  {running ? "実行中…" : "実行"}
+                </button>
               </div>
             </div>
-            <div className="relative flex-1" style={{ background: "var(--bg-code)" }}>
+            <div className="relative flex-1" style={{ background: "var(--bg-code)", minHeight: 0 }}>
               <MonacoEditor
                 height="100%"
                 language="typescript"
@@ -406,47 +400,65 @@ export function ProblemSolver({
               />
             </div>
           </div>
+        </div>
 
-          {/* Results */}
+        {/* Resizer (md+ only) */}
+        {/* biome-ignore lint/a11y/useSemanticElements: ARIA separator role is required for split-pane resize handles; <hr> cannot host interactive behavior */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="左ペインと結果ペインの横幅を調整"
+          aria-valuemin={MIN_LEFT_PX}
+          aria-valuenow={leftWidth ?? undefined}
+          tabIndex={0}
+          onMouseDown={onResizerMouseDown}
+          onKeyDown={onResizerKeyDown}
+          className="relative hidden cursor-col-resize touch-none items-center justify-center border-r border-l transition-colors hover:bg-[var(--bg-2)] focus-visible:bg-[var(--bg-2)] md:flex"
+          style={{
+            borderColor: "var(--line-1)",
+            background: "var(--bg-0)",
+          }}
+        >
+          <span
+            aria-hidden="true"
+            className="h-8 w-0.5 rounded"
+            style={{ background: "var(--line-2)" }}
+          />
+        </div>
+
+        {/* RIGHT pane: results */}
+        <div
+          className="flex min-h-[180px] flex-[0.9] flex-col overflow-hidden md:flex-1"
+          style={{ background: "var(--bg-0)", minWidth: 0 }}
+        >
           <div
-            className="flex flex-col overflow-hidden border-t"
-            style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
+            className="flex flex-shrink-0 items-center justify-between gap-2 border-b px-3 py-1.5"
+            style={{ borderColor: "var(--line-1)" }}
           >
-            <div
-              className="flex flex-shrink-0 items-center justify-between gap-2 border-b px-3 py-1.5"
-              style={{ borderColor: "var(--line-1)" }}
-            >
-              <div
-                className="inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1.5 font-medium text-[12px]"
-                style={{
-                  color: "var(--text-1)",
-                  background: "var(--bg-2)",
-                }}
+            <span className="text-[12px]" style={{ color: "var(--text-3)" }}>
+              実行結果
+            </span>
+            {running ? (
+              <span
+                className="cm-pulse inline-flex items-center gap-1.5 font-mono text-[11px]"
+                style={{ color: "var(--text-3)" }}
               >
-                <Play className="size-3" aria-hidden="true" /> 実行結果
-              </div>
-              {running ? (
-                <span
-                  className="cm-pulse inline-flex items-center gap-1.5 font-mono text-[11px]"
-                  style={{ color: "var(--text-3)" }}
-                >
-                  ● 実行中…
-                </span>
-              ) : null}
-            </div>
-            <div
-              className="flex-1 overflow-auto p-4 font-mono text-[12px]"
-              style={{ color: "var(--text-1)" }}
-            >
-              <ResultBody output={output} expected={expectedOutput} passed={passed} />
-            </div>
+                ● 実行中…
+              </span>
+            ) : null}
+          </div>
+          <div
+            className="flex-1 overflow-auto p-4 font-mono text-[12px]"
+            style={{ color: "var(--text-1)" }}
+          >
+            <ResultBody output={output} expected={expectedOutput} passed={passed} />
           </div>
         </div>
       </div>
 
-      {/* Bottom bar */}
+      {/* Bottom bar — navigation and hint only; the Run button now lives inside the editor toolbar */}
       <footer
-        className="grid items-center gap-4 border-t px-5 py-2.5"
+        className="grid flex-shrink-0 items-center gap-4 border-t px-5 py-2"
         style={{ gridTemplateColumns: "1fr auto 1fr", borderColor: "var(--line-1)" }}
       >
         <div className="flex gap-2">{footerLeft ?? <span />}</div>
@@ -457,21 +469,7 @@ export function ProblemSolver({
           {footerHint ??
             (expectedOutput ? "期待出力と一致すればクリア" : "実行して動作を確認しよう")}
         </div>
-        <div className="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            disabled={running}
-            onClick={run}
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-[10px] px-4 py-1.5 font-semibold text-[13px] transition",
-              running ? "cursor-not-allowed opacity-60" : "",
-            )}
-            style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
-          >
-            <Play className="size-3.5" aria-hidden="true" />
-            {running ? "実行中…" : "実行"}
-          </button>
-        </div>
+        <div />
       </footer>
     </div>
   );

--- a/src/components/problem-solver/ProblemSolver.tsx
+++ b/src/components/problem-solver/ProblemSolver.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, FileText, Play, RotateCcw, X } from "lucide-react";
+import { Check, ChevronDown, FileText, Play, RotateCcw, X } from "lucide-react";
 import dynamic from "next/dynamic";
 import {
   type CSSProperties,
@@ -69,6 +69,18 @@ export function ProblemSolver({
   const splitRef = useRef<HTMLDivElement>(null);
   const [leftWidth, setLeftWidth] = useState<number | null>(null);
   const draggingRef = useRef(false);
+
+  // Result panel auto-opens after a successful run, but stays collapsible so
+  // the editor can use the full height while the user is typing.
+  const [resultExpanded, setResultExpanded] = useState(false);
+  const lastOutputRef = useRef(output);
+  useEffect(() => {
+    // Open the result drawer the moment a fresh output lands (Run completed).
+    if (output && output !== lastOutputRef.current) {
+      setResultExpanded(true);
+    }
+    lastOutputRef.current = output;
+  }, [output]);
 
   const clampLeftWidth = useCallback((raw: number, containerWidth: number) => {
     const max = Math.max(MIN_LEFT_PX, containerWidth * MAX_LEFT_RATIO);
@@ -172,27 +184,24 @@ export function ProblemSolver({
       </header>
 
       {/*
-        md+ : horizontal split — left pane stacks problem above editor (with the
-        Run button on top of the editor), right pane shows execution results.
-        < md : the body itself becomes the scroll container so the three panes
-        can stack with relaxed min-heights without being clipped, and a
-        floating Run button is rendered below for one-tap reach.
+        md+ : horizontal split — left = problem, right = editor (top, main area)
+        + collapsible result drawer (bottom). The drawer auto-expands on Run
+        completion, leaves the editor full-height when collapsed.
+        < md : body scrolls; problem → editor → result stacked, plus a fixed
+        Run button bottom-right.
       */}
       <div
         ref={splitRef}
         className="flex min-h-0 flex-1 flex-col overflow-y-auto md:grid md:overflow-hidden"
         style={splitStyle}
       >
-        {/* LEFT pane: problem (top) + editor with Run toolbar (bottom) */}
+        {/* LEFT pane: problem statement only */}
         <div
-          className="flex min-h-0 flex-col overflow-visible border-b md:overflow-hidden md:border-b-0"
+          className="flex min-h-[140px] flex-[1] flex-col overflow-visible border-b md:min-h-0 md:overflow-hidden md:border-b-0"
           style={{ borderColor: "var(--line-1)", minWidth: 0 }}
         >
           {/* Problem statement */}
-          <div
-            className="flex min-h-[140px] flex-[1.1] flex-col overflow-visible border-b md:min-h-[180px] md:flex-1 md:overflow-hidden"
-            style={{ borderColor: "var(--line-1)" }}
-          >
+          <div className="flex min-h-0 flex-1 flex-col overflow-visible md:overflow-hidden">
             <div
               className="flex flex-shrink-0 items-center gap-0.5 border-b px-3 py-1.5"
               style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
@@ -333,82 +342,14 @@ export function ProblemSolver({
               </div>
             </div>
           </div>
-
-          {/* Editor */}
-          <div
-            className="flex min-h-[220px] flex-[1.4] flex-col overflow-hidden md:min-h-[260px] md:flex-1"
-            style={{ background: "var(--bg-code)" }}
-          >
-            <div
-              className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
-              style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
-            >
-              <div
-                className="flex items-center gap-2 text-[12px]"
-                style={{ color: "var(--text-3)" }}
-              >
-                <span
-                  className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
-                  style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}
-                >
-                  TypeScript
-                </span>
-                <span className="font-mono">main.ts</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={reset}
-                  className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-[12px] transition hover:bg-[var(--bg-2)]"
-                  style={{ color: "var(--text-2)" }}
-                >
-                  <RotateCcw className="size-3" aria-hidden="true" /> リセット
-                </button>
-                <button
-                  type="button"
-                  disabled={running}
-                  onClick={run}
-                  aria-label="コードを実行"
-                  className={cn(
-                    "inline-flex items-center gap-1.5 rounded-[8px] px-3.5 py-1.5 font-semibold text-[12.5px] transition",
-                    running ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
-                  )}
-                  style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
-                >
-                  <Play className="size-3.5" aria-hidden="true" />
-                  {running ? "実行中…" : "実行"}
-                </button>
-              </div>
-            </div>
-            <div className="relative flex-1" style={{ background: "var(--bg-code)", minHeight: 0 }}>
-              <MonacoEditor
-                height="100%"
-                language="typescript"
-                theme="vs-dark"
-                value={code}
-                onChange={(v) => setCode(v ?? "")}
-                options={{
-                  minimap: { enabled: false },
-                  fontSize: 13.5,
-                  lineHeight: 22,
-                  scrollBeyondLastLine: false,
-                  smoothScrolling: true,
-                  padding: { top: 12, bottom: 12 },
-                  tabSize: 2,
-                  fontFamily: "var(--font-mono-family)",
-                  fontLigatures: true,
-                }}
-              />
-            </div>
-          </div>
         </div>
 
-        {/* Resizer (md+ only) */}
+        {/* Resizer (md+ only): adjusts left = problem / right = editor+result widths */}
         {/* biome-ignore lint/a11y/useSemanticElements: ARIA separator role is required for split-pane resize handles; <hr> cannot host interactive behavior */}
         <div
           role="separator"
           aria-orientation="vertical"
-          aria-label="左ペインと結果ペインの横幅を調整"
+          aria-label="問題ペインとエディタペインの横幅を調整"
           aria-valuemin={MIN_LEFT_PX}
           aria-valuenow={leftWidth ?? undefined}
           tabIndex={0}
@@ -427,32 +368,133 @@ export function ProblemSolver({
           />
         </div>
 
-        {/* RIGHT pane: results */}
+        {/* RIGHT pane: editor (main) + collapsible result drawer (bottom) */}
         <div
-          className="flex min-h-[140px] flex-[0.9] flex-col overflow-visible md:min-h-[180px] md:flex-1 md:overflow-hidden"
-          style={{ background: "var(--bg-0)", minWidth: 0 }}
+          className="flex min-h-[260px] flex-[1.4] flex-col overflow-hidden md:min-h-0 md:flex-1"
+          style={{ background: "var(--bg-code)", minWidth: 0 }}
         >
+          {/* Editor toolbar */}
           <div
-            className="flex flex-shrink-0 items-center justify-between gap-2 border-b px-3 py-1.5"
-            style={{ borderColor: "var(--line-1)" }}
+            className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
+            style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
           >
-            <span className="text-[12px]" style={{ color: "var(--text-3)" }}>
-              実行結果
-            </span>
-            {running ? (
+            <div
+              className="flex items-center gap-2 text-[12px]"
+              style={{ color: "var(--text-3)" }}
+            >
               <span
-                className="cm-pulse inline-flex items-center gap-1.5 font-mono text-[11px]"
+                className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
+                style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}
+              >
+                TypeScript
+              </span>
+              <span className="font-mono">main.ts</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={reset}
+                className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-[12px] transition hover:bg-[var(--bg-2)]"
+                style={{ color: "var(--text-2)" }}
+              >
+                <RotateCcw className="size-3" aria-hidden="true" /> リセット
+              </button>
+              <button
+                type="button"
+                disabled={running}
+                onClick={run}
+                aria-label="コードを実行"
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-[8px] px-3.5 py-1.5 font-semibold text-[12.5px] transition",
+                  running ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
+                )}
+                style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
+              >
+                <Play className="size-3.5" aria-hidden="true" />
+                {running ? "実行中…" : "実行"}
+              </button>
+            </div>
+          </div>
+
+          {/* Monaco editor — main area, takes all remaining vertical space */}
+          <div className="relative flex-1" style={{ background: "var(--bg-code)", minHeight: 0 }}>
+            <MonacoEditor
+              height="100%"
+              language="typescript"
+              theme="vs-dark"
+              value={code}
+              onChange={(v) => setCode(v ?? "")}
+              options={{
+                minimap: { enabled: false },
+                fontSize: 13.5,
+                lineHeight: 22,
+                scrollBeyondLastLine: false,
+                smoothScrolling: true,
+                padding: { top: 12, bottom: 12 },
+                tabSize: 2,
+                fontFamily: "var(--font-mono-family)",
+                fontLigatures: true,
+              }}
+            />
+          </div>
+
+          {/* Collapsible result drawer */}
+          <div
+            className={cn(
+              "flex flex-shrink-0 flex-col border-t",
+              resultExpanded ? "h-[240px]" : "h-9",
+            )}
+            style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
+          >
+            <button
+              type="button"
+              onClick={() => setResultExpanded((prev) => !prev)}
+              className="flex flex-shrink-0 cursor-pointer items-center justify-between gap-2 border-b px-3 py-1.5 text-left transition-colors hover:bg-[var(--bg-2)]"
+              style={{ borderColor: resultExpanded ? "var(--line-1)" : "transparent" }}
+              aria-expanded={resultExpanded}
+              aria-controls="result-drawer-body"
+            >
+              <span
+                className="inline-flex items-center gap-2 text-[12px]"
                 style={{ color: "var(--text-3)" }}
               >
-                ● 実行中…
+                <ChevronDown
+                  className={cn(
+                    "size-3.5 transition-transform",
+                    resultExpanded ? "" : "-rotate-90",
+                  )}
+                  aria-hidden="true"
+                />
+                実行結果
+                {running ? (
+                  <span
+                    className="cm-pulse inline-flex items-center gap-1 font-mono text-[11px]"
+                    style={{ color: "var(--text-3)" }}
+                  >
+                    ● 実行中…
+                  </span>
+                ) : output ? (
+                  <span
+                    className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
+                    style={{
+                      background: passed ? "var(--ok-soft)" : "var(--err-soft)",
+                      color: passed ? "var(--ok)" : "var(--err)",
+                    }}
+                  >
+                    {passed ? "Accepted" : "Wrong Answer"}
+                  </span>
+                ) : null}
               </span>
+            </button>
+            {resultExpanded ? (
+              <div
+                id="result-drawer-body"
+                className="flex-1 overflow-auto p-4 font-mono text-[12px]"
+                style={{ color: "var(--text-1)" }}
+              >
+                <ResultBody output={output} expected={expectedOutput} passed={passed} />
+              </div>
             ) : null}
-          </div>
-          <div
-            className="flex-1 overflow-visible p-4 font-mono text-[12px] md:overflow-auto"
-            style={{ color: "var(--text-1)" }}
-          >
-            <ResultBody output={output} expected={expectedOutput} passed={passed} />
           </div>
         </div>
       </div>

--- a/src/repositories/bookmarkCollection.repository.ts
+++ b/src/repositories/bookmarkCollection.repository.ts
@@ -1,10 +1,20 @@
 import "server-only";
 
-import type { BookmarkCollection, Collection } from "@prisma/client";
+import type { BookmarkCollection, Collection, Problem } from "@prisma/client";
 import { BaseRepository } from "./base.repository";
 
+export type CollectionBookmarkAuthor = {
+  id: string;
+  name: string | null;
+  handle: string;
+  avatarUrl: string | null;
+};
+
 export type CollectionBookmarkWithCollection = BookmarkCollection & {
-  collection: Collection & { author: { handle: string } };
+  collection: Collection & {
+    author: CollectionBookmarkAuthor;
+    problems: Pick<Problem, "id">[];
+  };
 };
 
 export class BookmarkCollectionRepository extends BaseRepository {
@@ -14,7 +24,16 @@ export class BookmarkCollectionRepository extends BaseRepository {
       orderBy: { createdAt: "desc" },
       include: {
         collection: {
-          include: { author: { select: { handle: true } } },
+          include: {
+            author: {
+              select: { id: true, name: true, handle: true, avatarUrl: true },
+            },
+            problems: {
+              where: { isPublished: true },
+              select: { id: true },
+              orderBy: { order: "asc" },
+            },
+          },
         },
       },
     });

--- a/src/repositories/bookmarkCourse.repository.ts
+++ b/src/repositories/bookmarkCourse.repository.ts
@@ -1,10 +1,10 @@
 import "server-only";
 
-import type { BookmarkCourse, Course } from "@prisma/client";
+import type { BookmarkCourse, Course, Lesson } from "@prisma/client";
 import { BaseRepository } from "./base.repository";
 
 export type CourseBookmarkWithCourse = BookmarkCourse & {
-  course: Course;
+  course: Course & { lessons: Pick<Lesson, "id">[] };
 };
 
 export class BookmarkCourseRepository extends BaseRepository {
@@ -12,7 +12,17 @@ export class BookmarkCourseRepository extends BaseRepository {
     return this.client.bookmarkCourse.findMany({
       where: { userId },
       orderBy: { createdAt: "desc" },
-      include: { course: true },
+      include: {
+        course: {
+          include: {
+            lessons: {
+              where: { isPublished: true },
+              select: { id: true },
+              orderBy: { order: "asc" },
+            },
+          },
+        },
+      },
     });
   }
 


### PR DESCRIPTION
## Summary

Issue #80 で挙げられた 6 件の UX 課題をまとめて修正します。スコープは UI のみで、Prisma スキーマや認可の変更はありません。

- **(1) プロフィール副見出し削除**: `MyCollectionsSection` の冗長な副見出しを isOwner / 訪問者ブランチ両方で撤去。
- **(2) コミュニティコレクション詳細**: `{handle} · 問題 N` → `{handle (Link)} / 問題数 N` に変更。author handle はプロフィールに飛べるようにリンク化。
- **(3) 戻るボタン共通化**: `src/components/navigation/BackLink.tsx` を新設し、`router.back()` ベースの挙動にしたうえで履歴がない場合の `fallbackHref` を必ず指定。`/[handle]/[collection]`、`/[handle]/[collection]/[problem]`、`/learn/[course]`、`/learn/[course]/[lesson]`、`/settings/profile` の戻るリンクを置換。
- **(4) Card 全体クリック可能化**: `ContentCard` を stretched-link パターンに切替。タイトル `<Link>` の `::before` でカード全面をクリック領域にし、`HandleLink` 等の入れ子インタラクティブ要素は `relative z-10` で独立に押せるよう保持。
- **(5) `/{handle}/bookmarks` レイアウト統一**: BookmarkCollection / BookmarkCourse のリポジトリ include を `CollectionWithProblemsAndAuthor` / `CourseWithLessons` 互換に拡張し、Explore と同じ `CollectionCard` / `CourseCard` を再利用するよう変更。閲覧者の完了状況も同時取得して進捗バーを反映。
- **(6) ProblemSolver レイアウト**: 左ペインに問題と Monaco を縦に並べ、Monaco ツールバーへ primary な「実行」ボタンを sticky 表示。右ペインは実行結果専用に。`100vh` 内で各セクションを内部スクロールに閉じ込め、`md` 未満では縦積みのまま実行ボタンが viewport 内に残ることを担保。

## Test plan

- [ ] `npm run check` / `npx tsc --noEmit` / `npm run build` がローカルで通る
- [ ] `/{handle}` で副見出しが消えている (自他両方)
- [ ] `/{handle}/{collection}` で handle のリンクからプロフィールに遷移し、`/ 問題数 N` 表記になっている
- [ ] 戻るボタンが履歴に応じて `router.back()` する。新規タブから直接開いた場合は `fallbackHref` に飛ぶ
- [ ] Course / Collection カード全体のクリックで遷移、bookmark / handle は独立に押せる
- [ ] `/{handle}/bookmarks` の公式 / コミュニティタブで Explore と同じカードレイアウトが表示される
- [ ] `/learn/[course]/[lesson]` と `/{handle}/{collection}/{problem}` の両方で、Run ボタンが viewport 内に常に見える / コードを書いて実行 → 結果表示 → 期待出力一致でクリア badge の golden path が回る

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)