### PR TITLE
feat(executor): Sandpack 導入 (Phase 1) (Closes #82)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.4.1",
+        "@codesandbox/sandpack-react": "^2.20.0",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@prisma/adapter-pg": "^7.7.0",
@@ -703,6 +704,188 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@codesandbox/nodebox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
+      "integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
+      "license": "SEE LICENSE IN ./LICENSE",
+      "dependencies": {
+        "outvariant": "^1.4.0",
+        "strict-event-emitter": "^0.4.3"
+      }
+    },
+    "node_modules/@codesandbox/nodebox/node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "license": "MIT"
+    },
+    "node_modules/@codesandbox/sandpack-client": {
+      "version": "2.19.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.19.8.tgz",
+      "integrity": "sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codesandbox/nodebox": "0.1.8",
+        "buffer": "^6.0.3",
+        "dequal": "^2.0.2",
+        "mime-db": "^1.52.0",
+        "outvariant": "1.4.0",
+        "static-browser-server": "1.0.3"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-client/node_modules/outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "license": "MIT"
+    },
+    "node_modules/@codesandbox/sandpack-react": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-react/-/sandpack-react-2.20.0.tgz",
+      "integrity": "sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/commands": "^6.1.3",
+        "@codemirror/lang-css": "^6.0.1",
+        "@codemirror/lang-html": "^6.4.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.3.2",
+        "@codemirror/state": "^6.2.0",
+        "@codemirror/view": "^6.7.1",
+        "@codesandbox/sandpack-client": "^2.19.8",
+        "@lezer/highlight": "^1.1.3",
+        "@react-hook/intersection-observer": "^3.1.1",
+        "@stitches/core": "^1.2.6",
+        "anser": "^2.1.1",
+        "clean-set": "^1.1.2",
+        "dequal": "^2.0.2",
+        "escape-carriage": "^1.3.1",
+        "lz-string": "^1.4.4",
+        "react-devtools-inline": "4.4.0",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -1959,6 +2142,69 @@
       "version": "0.3.4",
       "license": "MIT"
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -2561,6 +2807,28 @@
         }
       }
     },
+    "node_modules/@react-hook/intersection-observer": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-hook/intersection-observer/-/intersection-observer-3.1.2.tgz",
+      "integrity": "sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-hook/passive-layout-effect": "^1.2.0",
+        "intersection-observer": "^0.10.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/passive-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -2587,6 +2855,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@stitches/core": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -3280,6 +3554,12 @@
         }
       }
     },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -3357,6 +3637,26 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.20",
@@ -3452,6 +3752,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bundle-name": {
@@ -3665,6 +3989,12 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
+    },
+    "node_modules/clean-set": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.2.tgz",
+      "integrity": "sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==",
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -3931,6 +4261,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "license": "MIT",
@@ -3958,6 +4294,19 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "license": "MIT"
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -4296,6 +4645,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "hasInstallScript": true,
@@ -4356,11 +4745,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-carriage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
+      "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==",
+      "license": "MIT"
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -4390,6 +4800,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/eventsource": {
@@ -4512,6 +4932,15 @@
     "node_modules/exsolve": {
       "version": "1.0.8",
       "license": "MIT"
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5128,6 +5557,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5162,6 +5611,13 @@
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "license": "MIT"
+    },
+    "node_modules/intersection-observer": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
+      "integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==",
+      "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+      "license": "W3C-20150513"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -5851,6 +6307,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -6974,6 +7439,12 @@
         "react-dom": ">= 18.2.0"
       }
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "funding": [
@@ -7818,6 +8289,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-devtools-inline": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz",
+      "integrity": "sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-symbol": "^3"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
@@ -7845,6 +8325,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -8477,6 +8963,36 @@
       "version": "1.0.7",
       "license": "MIT"
     },
+    "node_modules/static-browser-server": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
+      "integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.1.0",
+        "dotenv": "^16.0.3",
+        "mime-db": "^1.52.0",
+        "outvariant": "^1.3.0"
+      }
+    },
+    "node_modules/static-browser-server/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "license": "MIT"
+    },
+    "node_modules/static-browser-server/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8602,6 +9118,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -8835,6 +9357,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
       }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-fest": {
       "version": "5.6.0",
@@ -9094,6 +9622,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@codesandbox/sandpack-react": "^2.20.0",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@prisma/adapter-pg": "^7.7.0",

--- a/prisma/migrations/20260429234108_add_lesson_executor/migration.sql
+++ b/prisma/migrations/20260429234108_add_lesson_executor/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "LessonExecutor" AS ENUM ('WORKER', 'SANDPACK');
+
+-- AlterTable
+ALTER TABLE "Lesson" ADD COLUMN     "executor" "LessonExecutor" NOT NULL DEFAULT 'WORKER',
+ADD COLUMN     "sandpack_template" TEXT,
+ADD COLUMN     "starter_files" JSONB;
+
+-- AlterTable
+ALTER TABLE "problems" ADD COLUMN     "executor" "LessonExecutor" NOT NULL DEFAULT 'WORKER',
+ADD COLUMN     "sandpack_template" TEXT,
+ADD COLUMN     "starter_files" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,21 +24,32 @@ model Course {
   @@index([isPublished])
 }
 
+// Determines how the runtime executes a Lesson / Problem authoring payload.
+// WORKER   — esbuild-wasm + Web Worker (stdout-comparison style, default).
+// SANDPACK — CodeSandbox Sandpack iframe + bundler (DOM/React style).
+enum LessonExecutor {
+  WORKER
+  SANDPACK
+}
+
 model Lesson {
-  id             String           @id @default(cuid())
-  courseId       String
-  course         Course           @relation(fields: [courseId], references: [id], onDelete: Cascade)
-  slug           String
-  title          String
-  contentMd      String
-  starterCode    String
-  expectedOutput String?
-  order          Int
-  isPublished    Boolean          @default(false) @map("is_published")
-  progress       LessonProgress[]
-  bookmarks      BookmarkLesson[]
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @updatedAt    @map("updated_at")
+  id               String           @id @default(cuid())
+  courseId         String
+  course           Course           @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  slug             String
+  title            String
+  contentMd        String
+  starterCode      String
+  expectedOutput   String?
+  order            Int
+  isPublished      Boolean          @default(false) @map("is_published")
+  executor         LessonExecutor   @default(WORKER)
+  sandpackTemplate String?          @map("sandpack_template")
+  starterFiles     Json?            @map("starter_files")
+  progress         LessonProgress[]
+  bookmarks        BookmarkLesson[]
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt    @map("updated_at")
 
   @@unique([courseId, slug])
   @@index([courseId, isPublished])
@@ -127,20 +138,23 @@ model Collection {
 
 // UGC counterpart of Lesson.
 model Problem {
-  id             String            @id @default(cuid())
-  collectionId   String            @map("collection_id")
-  collection     Collection        @relation(fields: [collectionId], references: [id], onDelete: Cascade)
-  slug           String
-  title          String
-  contentMd      String            @map("content_md")
-  starterCode    String            @map("starter_code")
-  expectedOutput String?           @map("expected_output")
-  order          Int               @default(0)
-  isPublished    Boolean           @default(false) @map("is_published")
-  progress       ProblemProgress[]
-  bookmarks      BookmarkProblem[]
-  createdAt      DateTime          @default(now()) @map("created_at")
-  updatedAt      DateTime          @updatedAt      @map("updated_at")
+  id               String            @id @default(cuid())
+  collectionId     String            @map("collection_id")
+  collection       Collection        @relation(fields: [collectionId], references: [id], onDelete: Cascade)
+  slug             String
+  title            String
+  contentMd        String            @map("content_md")
+  starterCode      String            @map("starter_code")
+  expectedOutput   String?           @map("expected_output")
+  order            Int               @default(0)
+  isPublished      Boolean           @default(false) @map("is_published")
+  executor         LessonExecutor    @default(WORKER)
+  sandpackTemplate String?           @map("sandpack_template")
+  starterFiles     Json?             @map("starter_files")
+  progress         ProblemProgress[]
+  bookmarks        BookmarkProblem[]
+  createdAt        DateTime          @default(now()) @map("created_at")
+  updatedAt        DateTime          @updatedAt      @map("updated_at")
 
   @@unique([collectionId, slug])
   @@index([collectionId, isPublished])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,3 +1,5 @@
+import type { LessonExecutor } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
 type LessonSeed = {
@@ -7,6 +9,9 @@ type LessonSeed = {
   contentMd: string;
   starterCode: string;
   expectedOutput: string | null;
+  executor?: LessonExecutor;
+  sandpackTemplate?: string | null;
+  starterFiles?: Prisma.InputJsonValue | null;
 };
 
 type CourseSeed = {
@@ -790,6 +795,7 @@ console.log(describe(42));
         slug: "generics-basics",
         title: "ジェネリクスの基礎",
         order: 5,
+
         contentMd: `# ジェネリクスの基礎
 
 ジェネリクスは **型をパラメータ化** する仕組みです。関数や型に \`<T>\` を付けて、呼び出し時に型を決めます。
@@ -823,6 +829,44 @@ console.log(identity<number>(123));
       },
     ],
   },
+  {
+    slug: "react-fundamentals",
+    title: "React 基礎",
+    description: "ブラウザの Sandpack iframe 上で実 DOM を触りながら、React の基本を学びます。",
+    order: 2,
+    lessons: [
+      {
+        slug: "counter",
+        title: "Counter コンポーネント",
+        order: 1,
+        contentMd: `# Counter コンポーネント
+
+\`<App />\` の中に、ボタンを押すと数字が 1 ずつ増えるカウンターを実装してください。
+
+## やること
+
+- \`useState\` でカウント値を管理する
+- ボタンに \`onClick\` ハンドラを付け、クリックで count を +1 する
+- 現在のカウント値を画面に表示する
+
+右ペインのプレビューで動作確認しつつ、判定キーワード (\`useState\` と \`onClick\`) がコードに含まれていれば「クリア」になります。
+
+> 注意: このレッスンは Sandpack 上で動作します。WORKER 系レッスンとは別のランタイムです。
+`,
+        // WORKER fields kept empty — the SANDPACK pane reads sandpackTemplate /
+        // starterFiles instead. expectedOutput doubles as the comma-separated
+        // list of required tokens for the simple textual judge.
+        starterCode: "",
+        expectedOutput: "useState,onClick",
+        executor: "SANDPACK",
+        sandpackTemplate: "react-ts",
+        starterFiles: {
+          "/App.tsx":
+            'export default function App() {\n  // TODO: useState で count を管理し、ボタンの onClick で +1 するようにしてください\n  return (\n    <div style={{ padding: 24, fontFamily: "system-ui" }}>\n      <h1>Counter</h1>\n      <p>count: 0</p>\n      <button type="button">+1</button>\n    </div>\n  );\n}\n',
+        },
+      },
+    ],
+  },
 ];
 
 async function main() {
@@ -849,6 +893,9 @@ async function main() {
             starterCode: l.starterCode,
             expectedOutput: l.expectedOutput,
             isPublished: true,
+            executor: l.executor ?? "WORKER",
+            sandpackTemplate: l.sandpackTemplate ?? null,
+            starterFiles: l.starterFiles ?? Prisma.DbNull,
           })),
         },
       },

--- a/src/app/(protected)/[handle]/[collection]/[problem]/_components/ProblemSolverClient.tsx
+++ b/src/app/(protected)/[handle]/[collection]/[problem]/_components/ProblemSolverClient.tsx
@@ -5,6 +5,7 @@ import { completeProblemAction } from "@/actions/progress";
 import { BackLink } from "@/components/navigation/BackLink";
 import { ProblemSolver } from "@/components/problem-solver/ProblemSolver";
 import { type CollectionLinkable, collectionUrl } from "@/lib/routes";
+import type { Executor, SandpackStarterFiles, SandpackTemplate } from "@/types/problem";
 
 type Problem = {
   id: string;
@@ -13,6 +14,9 @@ type Problem = {
   contentMd: string;
   starterCode: string;
   expectedOutput: string | null;
+  executor: Executor;
+  sandpackTemplate: SandpackTemplate | null;
+  starterFiles: SandpackStarterFiles | null;
 };
 
 type Props = {
@@ -28,6 +32,9 @@ export function ProblemSolverClient({ collection, problem, initiallyCompleted }:
       contentMd={problem.contentMd}
       starterCode={problem.starterCode}
       expectedOutput={problem.expectedOutput}
+      executor={problem.executor}
+      sandpackTemplate={problem.sandpackTemplate}
+      starterFiles={problem.starterFiles}
       initialStatus={initiallyCompleted ? "COMPLETED" : "NOT_STARTED"}
       onSubmit={async ({ passed }) => {
         if (!passed) return;

--- a/src/app/(protected)/[handle]/[collection]/[problem]/page.tsx
+++ b/src/app/(protected)/[handle]/[collection]/[problem]/page.tsx
@@ -2,6 +2,7 @@ import type { Problem } from "@prisma/client";
 import { notFound } from "next/navigation";
 import { requireAuth } from "@/lib/auth";
 import { NotFoundError } from "@/lib/errors";
+import { coerceSandpackFields } from "@/lib/sandpack";
 import { getCollectionByHandleAndSlug } from "@/services/collectionService";
 import { isProblemCompleted } from "@/services/progressService";
 import { ProblemSolverClient } from "./_components/ProblemSolverClient";
@@ -26,6 +27,7 @@ export default async function ProblemPage({
   if (!problem) notFound();
 
   const completed = await isProblemCompleted(session.userId, problem.id);
+  const sandpack = coerceSandpackFields(problem);
 
   return (
     <ProblemSolverClient
@@ -41,6 +43,9 @@ export default async function ProblemPage({
         contentMd: problem.contentMd,
         starterCode: problem.starterCode,
         expectedOutput: problem.expectedOutput,
+        executor: problem.executor,
+        sandpackTemplate: sandpack.sandpackTemplate,
+        starterFiles: sandpack.starterFiles,
       }}
       initiallyCompleted={completed}
     />

--- a/src/app/(protected)/dashboard/collections/[collectionId]/problems/[problemId]/page.tsx
+++ b/src/app/(protected)/dashboard/collections/[collectionId]/problems/[problemId]/page.tsx
@@ -4,7 +4,7 @@ import { requireAuth } from "@/lib/auth";
 import { ForbiddenError, NotFoundError } from "@/lib/errors";
 import { getMyCollectionById } from "@/services/collectionService";
 import { getMyProblemById } from "@/services/problemService";
-import { ProblemForm } from "../new/_components/ProblemForm";
+import { ProblemForm, starterFilesToJsonString } from "../new/_components/ProblemForm";
 
 export const dynamic = "force-dynamic";
 
@@ -55,6 +55,9 @@ export default async function EditProblemPage({
           starterCode: problem.starterCode,
           expectedOutput: problem.expectedOutput ?? "",
           order: String(problem.order),
+          executor: problem.executor,
+          sandpackTemplate: problem.sandpackTemplate ?? "react-ts",
+          starterFilesJson: starterFilesToJsonString(problem.starterFiles),
         }}
       />
     </div>

--- a/src/app/(protected)/dashboard/collections/[collectionId]/problems/new/_components/ProblemForm.tsx
+++ b/src/app/(protected)/dashboard/collections/[collectionId]/problems/new/_components/ProblemForm.tsx
@@ -9,7 +9,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { CreateProblemSchema, UpdateProblemSchema } from "@/types/problem";
+import {
+  CreateProblemSchema,
+  type Executor,
+  ExecutorSchema,
+  SandpackStarterFilesSchema,
+  SandpackTemplateSchema,
+  UpdateProblemSchema,
+} from "@/types/problem";
 
 type Values = {
   slug: string;
@@ -18,6 +25,10 @@ type Values = {
   starterCode: string;
   expectedOutput: string;
   order: string;
+  executor: Executor;
+  sandpackTemplate: string;
+  /** JSON string edited by hand; parsed on submit. */
+  starterFilesJson: string;
 };
 
 type Props =
@@ -33,7 +44,16 @@ type Props =
       initial: Values;
     };
 
-type FieldKey = "slug" | "title" | "contentMd" | "starterCode" | "expectedOutput" | "order";
+type FieldKey =
+  | "slug"
+  | "title"
+  | "contentMd"
+  | "starterCode"
+  | "expectedOutput"
+  | "order"
+  | "executor"
+  | "sandpackTemplate"
+  | "starterFiles";
 
 const FIELD_KEYS: readonly FieldKey[] = [
   "slug",
@@ -42,7 +62,12 @@ const FIELD_KEYS: readonly FieldKey[] = [
   "starterCode",
   "expectedOutput",
   "order",
+  "executor",
+  "sandpackTemplate",
+  "starterFiles",
 ] as const;
+
+const SANDPACK_TEMPLATE_OPTIONS = SandpackTemplateSchema.options;
 
 const emptyValues: Values = {
   slug: "",
@@ -51,6 +76,10 @@ const emptyValues: Values = {
   starterCode: "",
   expectedOutput: "",
   order: "0",
+  executor: "WORKER",
+  sandpackTemplate: "react-ts",
+  starterFilesJson:
+    '{\n  "/App.tsx": "export default function App() {\\n  return <div>Hello</div>;\\n}\\n"\n}\n',
 };
 
 export function ProblemForm(props: Props) {
@@ -71,6 +100,17 @@ export function ProblemForm(props: Props) {
     setFieldErrors({});
 
     const orderNum = Number(values.order);
+    const isSandpack = values.executor === "SANDPACK";
+
+    let starterFilesParsed: unknown = null;
+    if (isSandpack) {
+      try {
+        starterFilesParsed = JSON.parse(values.starterFilesJson);
+      } catch (_err) {
+        setFieldErrors({ starterFiles: "JSON が不正です" });
+        return;
+      }
+    }
 
     const payload = {
       slug: values.slug,
@@ -79,6 +119,9 @@ export function ProblemForm(props: Props) {
       starterCode: values.starterCode,
       expectedOutput: values.expectedOutput.length === 0 ? null : values.expectedOutput,
       order: Number.isFinite(orderNum) ? orderNum : Number.NaN,
+      executor: values.executor,
+      sandpackTemplate: isSandpack ? values.sandpackTemplate : null,
+      starterFiles: isSandpack ? starterFilesParsed : null,
     };
 
     const parsed =
@@ -109,6 +152,8 @@ export function ProblemForm(props: Props) {
       router.refresh();
     });
   };
+
+  const isSandpack = values.executor === "SANDPACK";
 
   return (
     <form className="space-y-5" onSubmit={onSubmit}>
@@ -159,37 +204,135 @@ export function ProblemForm(props: Props) {
         )}
       </div>
 
-      <div className="space-y-1.5">
-        <Label id="problem-starter-label">スターターコード</Label>
-        <MonacoCodeInput
-          ariaLabelledBy="problem-starter-label"
-          height="300px"
-          id="problem-starter"
-          value={values.starterCode}
-          onChange={(v) => setValue("starterCode", v)}
-        />
-        {fieldErrors.starterCode && (
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">実行モード</legend>
+        <div className="flex flex-wrap gap-4 text-sm">
+          {ExecutorSchema.options.map((opt) => (
+            <label key={opt} className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="executor"
+                value={opt}
+                checked={values.executor === opt}
+                onChange={() => setValue("executor", opt)}
+              />
+              <span>
+                {opt === "WORKER"
+                  ? "WORKER (esbuild-wasm + Web Worker, stdout 比較)"
+                  : "SANDPACK (iframe + bundler, React/フロント)"}
+              </span>
+            </label>
+          ))}
+        </div>
+        {fieldErrors.executor && (
           <p className="text-xs text-destructive" role="alert">
-            {fieldErrors.starterCode}
+            {fieldErrors.executor}
           </p>
         )}
-      </div>
+      </fieldset>
 
-      <div className="space-y-1.5">
-        <Label htmlFor="problem-expected">期待出力 (空欄なら判定なし)</Label>
-        <Textarea
-          id="problem-expected"
-          rows={3}
-          value={values.expectedOutput}
-          onChange={(e) => setValue("expectedOutput", e.target.value)}
-          aria-invalid={!!fieldErrors.expectedOutput}
-        />
-        {fieldErrors.expectedOutput && (
-          <p className="text-xs text-destructive" role="alert">
-            {fieldErrors.expectedOutput}
-          </p>
-        )}
-      </div>
+      {!isSandpack ? (
+        <>
+          <div className="space-y-1.5">
+            <Label id="problem-starter-label">スターターコード</Label>
+            <MonacoCodeInput
+              ariaLabelledBy="problem-starter-label"
+              height="300px"
+              id="problem-starter"
+              value={values.starterCode}
+              onChange={(v) => setValue("starterCode", v)}
+            />
+            {fieldErrors.starterCode && (
+              <p className="text-xs text-destructive" role="alert">
+                {fieldErrors.starterCode}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="problem-expected">期待出力 (空欄なら判定なし)</Label>
+            <Textarea
+              id="problem-expected"
+              rows={3}
+              value={values.expectedOutput}
+              onChange={(e) => setValue("expectedOutput", e.target.value)}
+              aria-invalid={!!fieldErrors.expectedOutput}
+            />
+            {fieldErrors.expectedOutput && (
+              <p className="text-xs text-destructive" role="alert">
+                {fieldErrors.expectedOutput}
+              </p>
+            )}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="space-y-1.5">
+            <Label htmlFor="problem-sandpack-template">Sandpack テンプレート</Label>
+            <select
+              id="problem-sandpack-template"
+              className="block h-9 w-full rounded-md border bg-background px-3 text-sm"
+              value={values.sandpackTemplate}
+              onChange={(e) => setValue("sandpackTemplate", e.target.value)}
+              aria-invalid={!!fieldErrors.sandpackTemplate}
+            >
+              {SANDPACK_TEMPLATE_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+            {fieldErrors.sandpackTemplate && (
+              <p className="text-xs text-destructive" role="alert">
+                {fieldErrors.sandpackTemplate}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="problem-starter-files">スターターファイル (JSON)</Label>
+            <Textarea
+              id="problem-starter-files"
+              rows={10}
+              value={values.starterFilesJson}
+              onChange={(e) => setValue("starterFilesJson", e.target.value)}
+              aria-invalid={!!fieldErrors.starterFiles}
+              className="font-mono text-xs"
+              placeholder='{"/App.tsx": "..."}'
+            />
+            <p className="text-xs text-muted-foreground">
+              キーは <code>/</code> から始まるパス、値はファイル内容の文字列。
+            </p>
+            {fieldErrors.starterFiles && (
+              <p className="text-xs text-destructive" role="alert">
+                {fieldErrors.starterFiles}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="problem-expected">
+              判定キーワード (カンマ区切り、空欄なら判定なし)
+            </Label>
+            <Textarea
+              id="problem-expected"
+              rows={2}
+              value={values.expectedOutput}
+              onChange={(e) => setValue("expectedOutput", e.target.value)}
+              aria-invalid={!!fieldErrors.expectedOutput}
+              placeholder="useState,onClick"
+            />
+            <p className="text-xs text-muted-foreground">
+              指定したキーワードがファイル内容にすべて含まれていればクリア扱い。
+            </p>
+            {fieldErrors.expectedOutput && (
+              <p className="text-xs text-destructive" role="alert">
+                {fieldErrors.expectedOutput}
+              </p>
+            )}
+          </div>
+        </>
+      )}
 
       <div className="space-y-1.5">
         <Label htmlFor="problem-order">表示順</Label>
@@ -224,6 +367,15 @@ export function ProblemForm(props: Props) {
       </div>
     </form>
   );
+}
+
+// Re-export so the edit page can build initial Values without taking an extra
+// dependency on the schema module just for parsing JSON strings.
+export function starterFilesToJsonString(value: unknown): string {
+  if (value === null || value === undefined) return emptyValues.starterFilesJson;
+  const parsed = SandpackStarterFilesSchema.safeParse(value);
+  if (!parsed.success) return JSON.stringify(value, null, 2);
+  return JSON.stringify(parsed.data, null, 2);
 }
 
 function mapZodError(error: z.ZodError): Partial<Record<FieldKey, string>> {

--- a/src/app/(protected)/learn/[course]/[lesson]/_components/LessonSolver.tsx
+++ b/src/app/(protected)/learn/[course]/[lesson]/_components/LessonSolver.tsx
@@ -7,6 +7,7 @@ import { BookmarkButton } from "@/components/bookmarks/BookmarkButton";
 import { BackLink } from "@/components/navigation/BackLink";
 import { ProblemSolver } from "@/components/problem-solver/ProblemSolver";
 import { type CourseLinkable, learnUrl, lessonUrl } from "@/lib/routes";
+import type { Executor, SandpackStarterFiles, SandpackTemplate } from "@/types/problem";
 
 type Lesson = {
   id: string;
@@ -15,6 +16,9 @@ type Lesson = {
   contentMd: string;
   starterCode: string;
   expectedOutput: string | null;
+  executor: Executor;
+  sandpackTemplate: SandpackTemplate | null;
+  starterFiles: SandpackStarterFiles | null;
 };
 
 type Props = {
@@ -42,6 +46,9 @@ export function LessonSolver({
       contentMd={lesson.contentMd}
       starterCode={lesson.starterCode}
       expectedOutput={lesson.expectedOutput}
+      executor={lesson.executor}
+      sandpackTemplate={lesson.sandpackTemplate}
+      starterFiles={lesson.starterFiles}
       initialStatus={initiallyCompleted ? "COMPLETED" : "NOT_STARTED"}
       onSubmit={async ({ passed }) => {
         if (!passed) return;

--- a/src/app/(protected)/learn/[course]/[lesson]/page.tsx
+++ b/src/app/(protected)/learn/[course]/[lesson]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { requireAuth } from "@/lib/auth";
 import { NotFoundError } from "@/lib/errors";
+import { coerceSandpackFields } from "@/lib/sandpack";
 import { isLessonBookmarked } from "@/services/bookmarkService";
 import { getCourseBySlug } from "@/services/courseService";
 import { isLessonCompleted } from "@/services/progressService";
@@ -32,6 +33,8 @@ export default async function LessonPage({ params }: PageProps<"/learn/[course]/
     isLessonBookmarked({ userId: session.userId, lessonId: lesson.id }),
   ]);
 
+  const sandpack = coerceSandpackFields(lesson);
+
   return (
     <LessonSolver
       course={course}
@@ -43,6 +46,9 @@ export default async function LessonPage({ params }: PageProps<"/learn/[course]/
         contentMd: lesson.contentMd,
         starterCode: lesson.starterCode,
         expectedOutput: lesson.expectedOutput,
+        executor: lesson.executor,
+        sandpackTemplate: sandpack.sandpackTemplate,
+        starterFiles: sandpack.starterFiles,
       }}
       prevSlug={prev?.slug ?? null}
       nextSlug={next?.slug ?? null}

--- a/src/components/problem-solver/ProblemSolver.tsx
+++ b/src/components/problem-solver/ProblemSolver.tsx
@@ -1,645 +1,74 @@
 "use client";
 
-import { Check, ChevronDown, FileText, Play, RotateCcw, X } from "lucide-react";
 import dynamic from "next/dynamic";
-import {
-  type CSSProperties,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import { KEY_NUDGE_PX, MAX_LEFT_RATIO, MIN_LEFT_PX } from "@/config/editor";
-import { cn } from "@/lib/utils";
-import { type ProblemStatus, type ProblemSubmitResult, useProblemRunner } from "./useProblemRunner";
+import type { ReactNode } from "react";
+import type { Executor, SandpackStarterFiles, SandpackTemplate } from "@/types/problem";
+import type { ProblemStatus, ProblemSubmitResult } from "./useProblemRunner";
+import { WorkerProblemSolver } from "./WorkerProblemSolver";
 
-const MonacoEditor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
+// Sandpack pulls in CodeMirror, the bundler iframe wiring, and a hefty CSS
+// payload. Gate it behind next/dynamic so WORKER lessons (the default, and
+// the majority of existing content) never download the chunk. ssr:false is
+// required because Sandpack mounts an iframe.
+const SandpackProblemSolver = dynamic(
+  () => import("./SandpackProblemSolver").then((m) => m.SandpackProblemSolver),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="flex h-dvh items-center justify-center font-mono text-[12px]"
+        style={{ background: "var(--bg-0)", color: "var(--text-3)" }}
+      >
+        Sandpack を読み込み中…
+      </div>
+    ),
+  },
+);
 
-export type ProblemSolverProps = {
+type CommonProps = {
   title: string;
   contentMd: string;
   starterCode: string;
   expectedOutput: string | null;
   onSubmit?: (result: ProblemSubmitResult) => Promise<void>;
   initialStatus?: ProblemStatus;
-  /** Header chrome — left side (breadcrumb / back link). */
   headerLeft?: ReactNode;
-  /** Small line displayed under the title. */
   subtitle?: ReactNode;
-  /** Header chrome — right side, appended after the auto-rendered "クリア済み" badge. */
   headerRight?: ReactNode;
-  /** Footer chrome — left side (e.g. prev / next nav). */
   footerLeft?: ReactNode;
-  /** Footer chrome — center hint text (overrides the default). */
   footerHint?: ReactNode;
 };
 
-export function ProblemSolver({
-  title,
-  contentMd,
-  starterCode,
-  expectedOutput,
-  onSubmit,
-  initialStatus = "NOT_STARTED",
-  headerLeft,
-  subtitle,
-  headerRight,
-  footerLeft,
-  footerHint,
-}: ProblemSolverProps) {
-  const { code, setCode, output, running, completed, run, reset } = useProblemRunner({
-    starterCode,
-    expectedOutput,
-    initialStatus,
-    onSubmit,
-  });
+export type ProblemSolverProps = CommonProps & {
+  executor?: Executor;
+  sandpackTemplate?: SandpackTemplate | null;
+  starterFiles?: SandpackStarterFiles | null;
+};
 
-  const passed =
-    completed ||
-    (!!output &&
-      !output.stderr &&
-      !output.timedOut &&
-      output.exitCode === 0 &&
-      expectedOutput !== null &&
-      output.stdout.trim() === expectedOutput.trim());
+export function ProblemSolver(props: ProblemSolverProps) {
+  const { executor = "WORKER", sandpackTemplate, starterFiles, starterCode, ...rest } = props;
 
-  const splitRef = useRef<HTMLDivElement>(null);
-  const [leftWidth, setLeftWidth] = useState<number | null>(null);
-  const draggingRef = useRef(false);
-
-  // Result panel auto-opens after a successful run, but stays collapsible so
-  // the editor can use the full height while the user is typing.
-  const [resultExpanded, setResultExpanded] = useState(false);
-  const lastOutputRef = useRef(output);
-  useEffect(() => {
-    // Open the result drawer the moment a fresh output lands (Run completed).
-    if (output && output !== lastOutputRef.current) {
-      setResultExpanded(true);
+  if (executor === "SANDPACK") {
+    if (!sandpackTemplate || !starterFiles) {
+      // Schema-level invariant; surfaces only if a Lesson/Problem row was
+      // hand-edited to inconsistent state.
+      return (
+        <div
+          className="flex h-dvh items-center justify-center px-6 text-center font-mono text-[12px]"
+          style={{ background: "var(--bg-0)", color: "var(--err)" }}
+        >
+          このレッスンは SANDPACK 実行モードですが、template / starterFiles が設定されていません。
+        </div>
+      );
     }
-    lastOutputRef.current = output;
-  }, [output]);
-
-  const clampLeftWidth = useCallback((raw: number, containerWidth: number) => {
-    const max = Math.max(MIN_LEFT_PX, containerWidth * MAX_LEFT_RATIO);
-    return Math.max(MIN_LEFT_PX, Math.min(raw, max));
-  }, []);
-
-  const onResizerMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.button !== 0) return;
-    event.preventDefault();
-    draggingRef.current = true;
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-  }, []);
-
-  const onResizerKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (!splitRef.current) return;
-      const rect = splitRef.current.getBoundingClientRect();
-      const current = leftWidth ?? rect.width / 2;
-      if (event.key === "ArrowLeft") {
-        event.preventDefault();
-        setLeftWidth(clampLeftWidth(current - KEY_NUDGE_PX, rect.width));
-      } else if (event.key === "ArrowRight") {
-        event.preventDefault();
-        setLeftWidth(clampLeftWidth(current + KEY_NUDGE_PX, rect.width));
-      } else if (event.key === "Home") {
-        event.preventDefault();
-        setLeftWidth(MIN_LEFT_PX);
-      } else if (event.key === "End") {
-        event.preventDefault();
-        setLeftWidth(clampLeftWidth(rect.width * MAX_LEFT_RATIO, rect.width));
-      }
-    },
-    [leftWidth, clampLeftWidth],
-  );
-
-  useEffect(() => {
-    // Syncing drag state with window-level mouse events so dragging still works
-    // when the pointer leaves the resizer handle.
-    const onMove = (event: MouseEvent) => {
-      if (!draggingRef.current || !splitRef.current) return;
-      const rect = splitRef.current.getBoundingClientRect();
-      const raw = event.clientX - rect.left;
-      setLeftWidth(clampLeftWidth(raw, rect.width));
-    };
-    const onUp = () => {
-      if (!draggingRef.current) return;
-      draggingRef.current = false;
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-    window.addEventListener("mousemove", onMove);
-    window.addEventListener("mouseup", onUp);
-    return () => {
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
-    };
-  }, [clampLeftWidth]);
-
-  const splitStyle: CSSProperties =
-    leftWidth !== null
-      ? { gridTemplateColumns: `${leftWidth}px 6px minmax(0,1fr)` }
-      : {
-          gridTemplateColumns: "minmax(280px, 1.2fr) 6px minmax(360px, 1fr)",
-        };
-
-  return (
-    <div
-      className="flex h-dvh flex-col overflow-hidden"
-      style={{ background: "var(--bg-0)", color: "var(--text-1)" }}
-    >
-      {/* Problem top bar */}
-      <header
-        className="grid flex-shrink-0 items-center gap-4 border-b px-5 py-2.5"
-        style={{
-          gridTemplateColumns: "1fr auto 1fr",
-          borderColor: "var(--line-1)",
-          background: "var(--bg-0)",
-        }}
-      >
-        <div className="flex items-center gap-3">{headerLeft}</div>
-        <div className="text-center">
-          <h1 className="m-0 font-semibold text-[15px] tracking-tight">{title}</h1>
-          {subtitle ? (
-            <div className="mt-0.5 font-mono text-[11px]" style={{ color: "var(--text-4)" }}>
-              {subtitle}
-            </div>
-          ) : null}
-        </div>
-        <div className="flex items-center justify-end gap-2">
-          {passed ? (
-            <span
-              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 font-semibold text-[11px]"
-              style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
-            >
-              <Check className="size-3" aria-hidden="true" /> クリア済み
-            </span>
-          ) : null}
-          {headerRight}
-        </div>
-      </header>
-
-      {/*
-        md+ : horizontal split — left = problem, right = editor (top, main area)
-        + collapsible result drawer (bottom). The drawer auto-expands on Run
-        completion, leaves the editor full-height when collapsed.
-        < md : body scrolls; problem → editor → result stacked, plus a fixed
-        Run button bottom-right.
-      */}
-      <div
-        ref={splitRef}
-        className="flex min-h-0 flex-1 flex-col overflow-y-auto md:grid md:overflow-hidden"
-        style={splitStyle}
-      >
-        {/* LEFT pane: problem statement only */}
-        <div
-          className="flex min-h-[140px] flex-[1] flex-col overflow-visible border-b md:min-h-0 md:overflow-hidden md:border-b-0"
-          style={{ borderColor: "var(--line-1)", minWidth: 0 }}
-        >
-          {/* Problem statement */}
-          <div className="flex min-h-0 flex-1 flex-col overflow-visible md:overflow-hidden">
-            <div
-              className="flex flex-shrink-0 items-center gap-0.5 border-b px-3 py-1.5"
-              style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
-            >
-              <div
-                className="inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1.5 font-medium text-[12px]"
-                style={{ color: "var(--text-1)", background: "var(--bg-2)" }}
-              >
-                <FileText className="size-3.5" aria-hidden="true" /> 問題
-              </div>
-            </div>
-            <div className="flex-1 overflow-visible px-6 py-5 md:overflow-auto">
-              <div className="mx-auto max-w-[720px]" style={{ color: "var(--text-2)" }}>
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={{
-                    h1: ({ children }) => (
-                      <h1
-                        className="mt-1 mb-4 font-bold text-[22px] tracking-tight"
-                        style={{ color: "var(--text-1)" }}
-                      >
-                        {children}
-                      </h1>
-                    ),
-                    h2: ({ children }) => (
-                      <h2
-                        className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
-                        style={{ color: "var(--text-1)" }}
-                      >
-                        {children}
-                      </h2>
-                    ),
-                    h3: ({ children }) => (
-                      <h3
-                        className="mt-5 mb-2 font-semibold text-[14px]"
-                        style={{ color: "var(--text-1)" }}
-                      >
-                        {children}
-                      </h3>
-                    ),
-                    p: ({ children }) => <p className="mb-3 leading-7 text-[13.5px]">{children}</p>,
-                    code: ({ className, children, ...rest }) => {
-                      // react-markdown v10+ no longer passes an `inline` prop. Treat a single
-                      // text node without a language class as inline; anything structural
-                      // (multi-line content, nested nodes) is a fenced block.
-                      const isInline =
-                        !className && typeof children === "string" && !children.includes("\n");
-                      return isInline ? (
-                        <code
-                          className="rounded px-1.5 py-0.5 font-mono text-[0.9em]"
-                          style={{
-                            background: "var(--bg-2)",
-                            color: "var(--accent-solid)",
-                            border: "1px solid var(--line-1)",
-                          }}
-                        >
-                          {children}
-                        </code>
-                      ) : (
-                        <code className={className} {...rest}>
-                          {children}
-                        </code>
-                      );
-                    },
-                    pre: ({ children }) => (
-                      <pre
-                        className="mb-4 overflow-x-auto rounded-[10px] p-3 font-mono text-[12.5px] leading-relaxed"
-                        style={{
-                          background: "var(--bg-code)",
-                          border: "1px solid var(--line-1)",
-                          color: "var(--text-1)",
-                        }}
-                      >
-                        {children}
-                      </pre>
-                    ),
-                    ul: ({ children }) => (
-                      <ul className="mb-3 list-disc space-y-1 pl-5">{children}</ul>
-                    ),
-                    ol: ({ children }) => (
-                      <ol className="mb-3 list-decimal space-y-1 pl-5">{children}</ol>
-                    ),
-                    a: ({ href, children }) => (
-                      <a
-                        href={href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="underline"
-                        style={{ color: "var(--accent-solid)" }}
-                      >
-                        {children}
-                      </a>
-                    ),
-                    strong: ({ children }) => (
-                      <strong className="font-semibold" style={{ color: "var(--text-1)" }}>
-                        {children}
-                      </strong>
-                    ),
-                  }}
-                >
-                  {contentMd}
-                </ReactMarkdown>
-
-                {expectedOutput ? (
-                  <section className="mt-6">
-                    <h2
-                      className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
-                      style={{ color: "var(--text-1)" }}
-                    >
-                      期待される出力
-                    </h2>
-                    <div
-                      className="overflow-hidden rounded-[10px]"
-                      style={{
-                        background: "var(--bg-1)",
-                        border: "1px solid var(--line-1)",
-                      }}
-                    >
-                      <div
-                        className="border-b px-3 py-2 font-mono text-[11px]"
-                        style={{
-                          borderColor: "var(--line-1)",
-                          background: "var(--bg-2)",
-                          color: "var(--text-3)",
-                        }}
-                      >
-                        Expected stdout
-                      </div>
-                      <pre
-                        className="m-0 p-3 font-mono text-[12.5px] leading-relaxed"
-                        style={{ background: "var(--bg-code)", color: "var(--text-1)" }}
-                      >
-                        {expectedOutput}
-                      </pre>
-                    </div>
-                  </section>
-                ) : null}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Resizer (md+ only): adjusts left = problem / right = editor+result widths */}
-        {/* biome-ignore lint/a11y/useSemanticElements: ARIA separator role is required for split-pane resize handles; <hr> cannot host interactive behavior */}
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="問題ペインとエディタペインの横幅を調整"
-          aria-valuemin={MIN_LEFT_PX}
-          aria-valuemax={
-            splitRef.current
-              ? Math.max(
-                  MIN_LEFT_PX,
-                  splitRef.current.getBoundingClientRect().width * MAX_LEFT_RATIO,
-                )
-              : undefined
-          }
-          aria-valuenow={leftWidth ?? undefined}
-          tabIndex={0}
-          onMouseDown={onResizerMouseDown}
-          onKeyDown={onResizerKeyDown}
-          className="relative hidden cursor-col-resize touch-none items-center justify-center border-r border-l transition-colors hover:bg-[var(--bg-2)] focus-visible:bg-[var(--bg-2)] md:flex"
-          style={{
-            borderColor: "var(--line-1)",
-            background: "var(--bg-0)",
-          }}
-        >
-          <span
-            aria-hidden="true"
-            className="h-8 w-0.5 rounded"
-            style={{ background: "var(--line-2)" }}
-          />
-        </div>
-
-        {/* RIGHT pane: editor (main) + collapsible result drawer (bottom) */}
-        <div
-          className="flex min-h-[260px] flex-[1.4] flex-col overflow-hidden md:min-h-0 md:flex-1"
-          style={{ background: "var(--bg-code)", minWidth: 0 }}
-        >
-          {/* Editor toolbar */}
-          <div
-            className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
-            style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
-          >
-            <div className="flex items-center gap-2 text-[12px]" style={{ color: "var(--text-3)" }}>
-              <span
-                className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
-                style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}
-              >
-                TypeScript
-              </span>
-              <span className="font-mono">main.ts</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={reset}
-                className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-[12px] transition hover:bg-[var(--bg-2)]"
-                style={{ color: "var(--text-2)" }}
-              >
-                <RotateCcw className="size-3" aria-hidden="true" /> リセット
-              </button>
-              <button
-                type="button"
-                disabled={running}
-                onClick={run}
-                aria-label="コードを実行"
-                className={cn(
-                  "inline-flex items-center gap-1.5 rounded-[8px] px-3.5 py-1.5 font-semibold text-[12.5px] transition",
-                  running ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
-                )}
-                style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
-              >
-                <Play className="size-3.5" aria-hidden="true" />
-                {running ? "実行中…" : "実行"}
-              </button>
-            </div>
-          </div>
-
-          {/* Monaco editor — main area, takes all remaining vertical space */}
-          <div className="relative flex-1" style={{ background: "var(--bg-code)", minHeight: 0 }}>
-            <MonacoEditor
-              height="100%"
-              language="typescript"
-              theme="vs-dark"
-              value={code}
-              onChange={(v) => setCode(v ?? "")}
-              options={{
-                minimap: { enabled: false },
-                fontSize: 13.5,
-                lineHeight: 22,
-                scrollBeyondLastLine: false,
-                smoothScrolling: true,
-                padding: { top: 12, bottom: 12 },
-                tabSize: 2,
-                fontFamily: "var(--font-mono-family)",
-                fontLigatures: true,
-              }}
-            />
-          </div>
-
-          {/* Collapsible result drawer */}
-          <div
-            className={cn(
-              "flex flex-shrink-0 flex-col border-t",
-              resultExpanded ? "h-[240px]" : "h-9",
-            )}
-            style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
-          >
-            <button
-              type="button"
-              onClick={() => setResultExpanded((prev) => !prev)}
-              className="flex flex-shrink-0 cursor-pointer items-center justify-between gap-2 border-b px-3 py-1.5 text-left transition-colors hover:bg-[var(--bg-2)]"
-              style={{ borderColor: resultExpanded ? "var(--line-1)" : "transparent" }}
-              aria-expanded={resultExpanded}
-              aria-controls="result-drawer-body"
-            >
-              <span
-                className="inline-flex items-center gap-2 text-[12px]"
-                style={{ color: "var(--text-3)" }}
-              >
-                <ChevronDown
-                  className={cn(
-                    "size-3.5 transition-transform",
-                    resultExpanded ? "" : "-rotate-90",
-                  )}
-                  aria-hidden="true"
-                />
-                実行結果
-                {running ? (
-                  <span
-                    className="cm-pulse inline-flex items-center gap-1 font-mono text-[11px]"
-                    style={{ color: "var(--text-3)" }}
-                  >
-                    ● 実行中…
-                  </span>
-                ) : output ? (
-                  <span
-                    className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
-                    style={{
-                      background: passed ? "var(--ok-soft)" : "var(--err-soft)",
-                      color: passed ? "var(--ok)" : "var(--err)",
-                    }}
-                  >
-                    {passed ? "Accepted" : "Wrong Answer"}
-                  </span>
-                ) : null}
-              </span>
-            </button>
-            {resultExpanded ? (
-              <div
-                id="result-drawer-body"
-                className="flex-1 overflow-auto p-4 font-mono text-[12px]"
-                style={{ color: "var(--text-1)" }}
-              >
-                <ResultBody output={output} expected={expectedOutput} passed={passed} />
-              </div>
-            ) : null}
-          </div>
-        </div>
-      </div>
-
-      {/* Mobile-only floating Run button — keeps the primary action one tap away
-          regardless of how far the user has scrolled the body on small screens. */}
-      <button
-        type="button"
-        disabled={running}
-        onClick={run}
-        aria-label="コードを実行"
-        className={cn(
-          "fixed right-4 bottom-16 z-30 inline-flex items-center gap-1.5 rounded-full px-5 py-3 font-semibold text-[13px] shadow-lg transition md:hidden",
-          running ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
-        )}
-        style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
-      >
-        <Play className="size-4" aria-hidden="true" />
-        {running ? "実行中…" : "実行"}
-      </button>
-
-      {/* Bottom bar — navigation and hint only; the Run button now lives inside the editor toolbar */}
-      <footer
-        className="grid flex-shrink-0 items-center gap-4 border-t px-5 py-2"
-        style={{ gridTemplateColumns: "1fr auto 1fr", borderColor: "var(--line-1)" }}
-      >
-        <div className="flex gap-2">{footerLeft ?? <span />}</div>
-        <div
-          className="flex items-center gap-1.5 font-mono text-[11px]"
-          style={{ color: "var(--text-3)" }}
-        >
-          {footerHint ??
-            (expectedOutput ? "期待出力と一致すればクリア" : "実行して動作を確認しよう")}
-        </div>
-        <div />
-      </footer>
-    </div>
-  );
-}
-
-function ResultBody({
-  output,
-  expected,
-  passed,
-}: {
-  output: ReturnType<typeof useProblemRunner>["output"];
-  expected: string | null;
-  passed: boolean;
-}) {
-  if (!output) {
     return (
-      <div className="py-10 text-center font-sans text-[13px]" style={{ color: "var(--text-3)" }}>
-        実行するとここに結果が表示されます
-      </div>
+      <SandpackProblemSolver
+        {...rest}
+        sandpackTemplate={sandpackTemplate}
+        starterFiles={starterFiles}
+      />
     );
   }
 
-  const hasStderr = !!output.stderr;
-  const hasStdout = !!output.stdout;
-
-  return (
-    <div className="space-y-3">
-      {expected !== null ? (
-        <div
-          className="flex items-center gap-2 rounded-[8px] px-3 py-2 font-sans text-[12.5px]"
-          style={{
-            background: passed ? "var(--ok-soft)" : "var(--err-soft)",
-            border: `1px solid ${passed ? "oklch(0.82 0.16 145 / 0.4)" : "oklch(0.72 0.19 25 / 0.4)"}`,
-            color: passed ? "var(--ok)" : "var(--err)",
-          }}
-        >
-          {passed ? (
-            <Check className="size-4" aria-hidden="true" />
-          ) : (
-            <X className="size-4" aria-hidden="true" />
-          )}
-          <b>{passed ? "Accepted — 期待出力と一致!" : "Wrong Answer — 期待出力と一致しません"}</b>
-        </div>
-      ) : null}
-
-      {hasStdout ? (
-        <div
-          className="overflow-hidden rounded-[8px]"
-          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
-        >
-          <div
-            className="border-b px-3 py-1.5 font-mono text-[11px]"
-            style={{
-              borderColor: "var(--line-1)",
-              background: "var(--bg-2)",
-              color: "var(--text-3)",
-            }}
-          >
-            stdout
-          </div>
-          <pre className="m-0 whitespace-pre-wrap break-all p-3" style={{ color: "var(--text-1)" }}>
-            {output.stdout}
-          </pre>
-        </div>
-      ) : null}
-
-      {hasStderr ? (
-        <div
-          className="overflow-hidden rounded-[8px]"
-          style={{ background: "var(--bg-1)", border: "1px solid oklch(0.72 0.19 25 / 0.4)" }}
-        >
-          <div
-            className="border-b px-3 py-1.5 font-mono text-[11px]"
-            style={{
-              borderColor: "var(--line-1)",
-              background: "var(--bg-2)",
-              color: "var(--err)",
-            }}
-          >
-            stderr
-          </div>
-          <pre className="m-0 whitespace-pre-wrap break-all p-3" style={{ color: "var(--err)" }}>
-            {output.stderr}
-          </pre>
-        </div>
-      ) : null}
-
-      {output.timedOut ? (
-        <div
-          className="rounded-[8px] px-3 py-2 font-sans text-[12.5px]"
-          style={{
-            background: "var(--warn-soft)",
-            border: "1px solid oklch(0.84 0.15 85 / 0.4)",
-            color: "var(--warn)",
-          }}
-        >
-          ⏱ タイムアウト (5s)
-        </div>
-      ) : null}
-
-      {!hasStdout && !hasStderr && !output.timedOut ? (
-        <div className="font-sans" style={{ color: "var(--text-3)" }}>
-          (出力なし)
-        </div>
-      ) : null}
-    </div>
-  );
+  return <WorkerProblemSolver {...rest} starterCode={starterCode} />;
 }

--- a/src/components/problem-solver/SandpackProblemSolver.tsx
+++ b/src/components/problem-solver/SandpackProblemSolver.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import {
+  SandpackCodeEditor,
+  SandpackLayout,
+  SandpackPreview,
+  SandpackProvider,
+  type SandpackProviderProps,
+  useSandpack,
+} from "@codesandbox/sandpack-react";
+import { Check, FileText, Play, X } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { cn } from "@/lib/utils";
+import type { SandpackStarterFiles, SandpackTemplate } from "@/types/problem";
+import type { ProblemStatus, ProblemSubmitResult } from "./useProblemRunner";
+
+export type SandpackProblemSolverProps = {
+  title: string;
+  contentMd: string;
+  /** Comma-separated tokens that must appear in any sandpack file for the
+   *  attempt to pass. `null` disables auto-judgement (free-form). */
+  expectedOutput: string | null;
+  sandpackTemplate: SandpackTemplate;
+  starterFiles: SandpackStarterFiles;
+  onSubmit?: (result: ProblemSubmitResult) => Promise<void>;
+  initialStatus?: ProblemStatus;
+  headerLeft?: ReactNode;
+  subtitle?: ReactNode;
+  headerRight?: ReactNode;
+  footerLeft?: ReactNode;
+  footerHint?: ReactNode;
+};
+
+type JudgeOutcome = {
+  passed: boolean;
+  missingTokens: string[];
+};
+
+function parseRequiredTokens(spec: string | null): string[] {
+  if (!spec) return [];
+  return spec
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function SandpackProblemSolver({
+  title,
+  contentMd,
+  expectedOutput,
+  sandpackTemplate,
+  starterFiles,
+  onSubmit,
+  initialStatus = "NOT_STARTED",
+  headerLeft,
+  subtitle,
+  headerRight,
+  footerLeft,
+  footerHint,
+}: SandpackProblemSolverProps) {
+  const requiredTokens = parseRequiredTokens(expectedOutput);
+  const [completed, setCompleted] = useState(initialStatus === "COMPLETED");
+
+  const sandpackFiles: SandpackProviderProps["files"] = starterFiles;
+
+  return (
+    <div
+      className="flex h-dvh flex-col overflow-hidden"
+      style={{ background: "var(--bg-0)", color: "var(--text-1)" }}
+    >
+      <header
+        className="grid flex-shrink-0 items-center gap-4 border-b px-5 py-2.5"
+        style={{
+          gridTemplateColumns: "1fr auto 1fr",
+          borderColor: "var(--line-1)",
+          background: "var(--bg-0)",
+        }}
+      >
+        <div className="flex items-center gap-3">{headerLeft}</div>
+        <div className="text-center">
+          <h1 className="m-0 font-semibold text-[15px] tracking-tight">{title}</h1>
+          {subtitle ? (
+            <div className="mt-0.5 font-mono text-[11px]" style={{ color: "var(--text-4)" }}>
+              {subtitle}
+            </div>
+          ) : null}
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          {completed ? (
+            <span
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 font-semibold text-[11px]"
+              style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
+            >
+              <Check className="size-3" aria-hidden="true" /> クリア済み
+            </span>
+          ) : null}
+          {headerRight}
+        </div>
+      </header>
+
+      <div
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto md:grid md:overflow-hidden"
+        style={{ gridTemplateColumns: "minmax(280px, 1.2fr) minmax(360px, 1fr)" }}
+      >
+        {/* LEFT pane: problem statement (mirrors WorkerProblemSolver). */}
+        <div
+          className="flex min-h-[140px] flex-[1] flex-col overflow-visible border-b md:min-h-0 md:overflow-hidden md:border-r md:border-b-0"
+          style={{ borderColor: "var(--line-1)", minWidth: 0 }}
+        >
+          <div
+            className="flex flex-shrink-0 items-center gap-0.5 border-b px-3 py-1.5"
+            style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
+          >
+            <div
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1.5 font-medium text-[12px]"
+              style={{ color: "var(--text-1)", background: "var(--bg-2)" }}
+            >
+              <FileText className="size-3.5" aria-hidden="true" /> 問題
+            </div>
+          </div>
+          <div className="flex-1 overflow-visible px-6 py-5 md:overflow-auto">
+            <div className="mx-auto max-w-[720px]" style={{ color: "var(--text-2)" }}>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  h1: ({ children }) => (
+                    <h1
+                      className="mt-1 mb-4 font-bold text-[22px] tracking-tight"
+                      style={{ color: "var(--text-1)" }}
+                    >
+                      {children}
+                    </h1>
+                  ),
+                  h2: ({ children }) => (
+                    <h2
+                      className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
+                      style={{ color: "var(--text-1)" }}
+                    >
+                      {children}
+                    </h2>
+                  ),
+                  p: ({ children }) => <p className="mb-3 leading-7 text-[13.5px]">{children}</p>,
+                  code: ({ className, children, ...rest }) => {
+                    const isInline =
+                      !className && typeof children === "string" && !children.includes("\n");
+                    return isInline ? (
+                      <code
+                        className="rounded px-1.5 py-0.5 font-mono text-[0.9em]"
+                        style={{
+                          background: "var(--bg-2)",
+                          color: "var(--accent-solid)",
+                          border: "1px solid var(--line-1)",
+                        }}
+                      >
+                        {children}
+                      </code>
+                    ) : (
+                      <code className={className} {...rest}>
+                        {children}
+                      </code>
+                    );
+                  },
+                  pre: ({ children }) => (
+                    <pre
+                      className="mb-4 overflow-x-auto rounded-[10px] p-3 font-mono text-[12.5px] leading-relaxed"
+                      style={{
+                        background: "var(--bg-code)",
+                        border: "1px solid var(--line-1)",
+                        color: "var(--text-1)",
+                      }}
+                    >
+                      {children}
+                    </pre>
+                  ),
+                  ul: ({ children }) => (
+                    <ul className="mb-3 list-disc space-y-1 pl-5">{children}</ul>
+                  ),
+                  ol: ({ children }) => (
+                    <ol className="mb-3 list-decimal space-y-1 pl-5">{children}</ol>
+                  ),
+                }}
+              >
+                {contentMd}
+              </ReactMarkdown>
+
+              {requiredTokens.length > 0 ? (
+                <section className="mt-6">
+                  <h2
+                    className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
+                    style={{ color: "var(--text-1)" }}
+                  >
+                    判定条件 (必須キーワード)
+                  </h2>
+                  <ul className="mb-3 list-disc space-y-1 pl-5 font-mono text-[12px]">
+                    {requiredTokens.map((token) => (
+                      <li key={token}>{token}</li>
+                    ))}
+                  </ul>
+                </section>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT pane: Sandpack editor + preview. */}
+        <div
+          className="flex min-h-[260px] flex-[1.4] flex-col overflow-hidden md:min-h-0 md:flex-1"
+          style={{ background: "var(--bg-code)", minWidth: 0 }}
+        >
+          <SandpackProvider
+            template={sandpackTemplate}
+            files={sandpackFiles}
+            theme="dark"
+            options={{
+              recompileMode: "delayed",
+              recompileDelay: 500,
+            }}
+          >
+            <SandpackJudgeBar
+              completed={completed}
+              requiredTokens={requiredTokens}
+              onPass={async (code) => {
+                if (completed) return;
+                setCompleted(true);
+                if (!onSubmit) return;
+                try {
+                  await onSubmit({ passed: true, output: "", code });
+                } catch (err) {
+                  setCompleted(false);
+                  console.error("[SandpackProblemSolver] onSubmit threw:", err);
+                }
+              }}
+            />
+            <SandpackLayout
+              style={{
+                flex: 1,
+                minHeight: 0,
+                border: "none",
+                borderRadius: 0,
+              }}
+            >
+              <SandpackCodeEditor
+                showLineNumbers
+                showInlineErrors
+                wrapContent
+                style={{ height: "100%", flex: 1 }}
+              />
+              <SandpackPreview style={{ height: "100%", flex: 1 }} showOpenInCodeSandbox={false} />
+            </SandpackLayout>
+          </SandpackProvider>
+        </div>
+      </div>
+
+      <footer
+        className="grid flex-shrink-0 items-center gap-4 border-t px-5 py-2"
+        style={{ gridTemplateColumns: "1fr auto 1fr", borderColor: "var(--line-1)" }}
+      >
+        <div className="flex gap-2">{footerLeft ?? <span />}</div>
+        <div
+          className="flex items-center gap-1.5 font-mono text-[11px]"
+          style={{ color: "var(--text-3)" }}
+        >
+          {footerHint ??
+            (requiredTokens.length > 0
+              ? "必須キーワードがすべて含まれていればクリア"
+              : "プレビューで動作を確認しよう")}
+        </div>
+        <div />
+      </footer>
+    </div>
+  );
+}
+
+function judgeFiles(
+  files: Record<string, { code: string }>,
+  requiredTokens: string[],
+): JudgeOutcome {
+  if (requiredTokens.length === 0) return { passed: false, missingTokens: [] };
+  const haystack = Object.values(files)
+    .map((f) => f.code ?? "")
+    .join("\n");
+  const missingTokens = requiredTokens.filter((token) => !haystack.includes(token));
+  return { passed: missingTokens.length === 0, missingTokens };
+}
+
+function SandpackJudgeBar({
+  completed,
+  requiredTokens,
+  onPass,
+}: {
+  completed: boolean;
+  requiredTokens: string[];
+  onPass: (code: string) => Promise<void>;
+}) {
+  const { sandpack } = useSandpack();
+  const [outcome, setOutcome] = useState<JudgeOutcome | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const canJudge = requiredTokens.length > 0;
+
+  const handleJudge = async () => {
+    const result = judgeFiles(sandpack.files, requiredTokens);
+    setOutcome(result);
+    if (!result.passed) return;
+    setSubmitting(true);
+    try {
+      await onPass(JSON.stringify(sandpack.files));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
+      style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
+    >
+      <div className="flex items-center gap-2 text-[12px]" style={{ color: "var(--text-3)" }}>
+        <span
+          className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
+          style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}
+        >
+          Sandpack
+        </span>
+        {outcome && !outcome.passed ? (
+          <span
+            className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
+            style={{ background: "var(--err-soft)", color: "var(--err)" }}
+          >
+            <X className="size-3" aria-hidden="true" /> 未達: {outcome.missingTokens.join(", ")}
+          </span>
+        ) : null}
+        {(outcome?.passed || completed) && requiredTokens.length > 0 ? (
+          <span
+            className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
+            style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
+          >
+            <Check className="size-3" aria-hidden="true" /> 判定 OK
+          </span>
+        ) : null}
+      </div>
+      {canJudge ? (
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={handleJudge}
+          aria-label="判定する"
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-[8px] px-3.5 py-1.5 font-semibold text-[12.5px] transition",
+            submitting ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
+          )}
+          style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
+        >
+          <Play className="size-3.5" aria-hidden="true" />
+          {submitting ? "判定中…" : "判定"}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/problem-solver/SandpackProblemSolver.tsx
+++ b/src/components/problem-solver/SandpackProblemSolver.tsx
@@ -218,15 +218,18 @@ export function SandpackProblemSolver({
               recompileDelay: 500,
             }}
           >
-            <SandpackJudgeBar
+            <SandpackJudgeControls
               completed={completed}
               requiredTokens={requiredTokens}
-              onPass={async (code) => {
+              onPass={async () => {
                 if (completed) return;
                 setCompleted(true);
                 if (!onSubmit) return;
                 try {
-                  await onSubmit({ passed: true, output: "", code });
+                  // The Sandpack runner has no single "submitted code" payload;
+                  // the textual judge ran on the file map, and the WORKER-style
+                  // `code` field is unused by the current onSubmit consumers.
+                  await onSubmit({ passed: true, output: "", code: "" });
                 } catch (err) {
                   setCompleted(false);
                   console.error("[SandpackProblemSolver] onSubmit threw:", err);
@@ -285,14 +288,14 @@ function judgeFiles(
   return { passed: missingTokens.length === 0, missingTokens };
 }
 
-function SandpackJudgeBar({
+function SandpackJudgeControls({
   completed,
   requiredTokens,
   onPass,
 }: {
   completed: boolean;
   requiredTokens: string[];
-  onPass: (code: string) => Promise<void>;
+  onPass: () => Promise<void>;
 }) {
   const { sandpack } = useSandpack();
   const [outcome, setOutcome] = useState<JudgeOutcome | null>(null);
@@ -305,41 +308,65 @@ function SandpackJudgeBar({
     if (!result.passed) return;
     setSubmitting(true);
     try {
-      await onPass(JSON.stringify(sandpack.files));
+      await onPass();
     } finally {
       setSubmitting(false);
     }
   };
 
   return (
-    <div
-      className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
-      style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
-    >
-      <div className="flex items-center gap-2 text-[12px]" style={{ color: "var(--text-3)" }}>
-        <span
-          className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
-          style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}
-        >
-          Sandpack
-        </span>
-        {outcome && !outcome.passed ? (
+    <>
+      <div
+        className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
+        style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
+      >
+        <div className="flex items-center gap-2 text-[12px]" style={{ color: "var(--text-3)" }}>
           <span
-            className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
-            style={{ background: "var(--err-soft)", color: "var(--err)" }}
+            className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
+            style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}
           >
-            <X className="size-3" aria-hidden="true" /> 未達: {outcome.missingTokens.join(", ")}
+            Sandpack
           </span>
-        ) : null}
-        {(outcome?.passed || completed) && requiredTokens.length > 0 ? (
-          <span
-            className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
-            style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
+          {/* role="status" + aria-live announces judge feedback to screen readers */}
+          <span role="status" aria-live="polite" className="flex items-center gap-2">
+            {outcome && !outcome.passed ? (
+              <span
+                className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
+                style={{ background: "var(--err-soft)", color: "var(--err)" }}
+              >
+                <X className="size-3" aria-hidden="true" /> 未達: {outcome.missingTokens.join(", ")}
+              </span>
+            ) : null}
+            {(outcome?.passed || completed) && requiredTokens.length > 0 ? (
+              <span
+                className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
+                style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
+              >
+                <Check className="size-3" aria-hidden="true" /> 判定 OK
+              </span>
+            ) : null}
+          </span>
+        </div>
+        {canJudge ? (
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={handleJudge}
+            aria-label="判定する"
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-[8px] px-3.5 py-1.5 font-semibold text-[12.5px] transition",
+              submitting ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
+            )}
+            style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
           >
-            <Check className="size-3" aria-hidden="true" /> 判定 OK
-          </span>
+            <Play className="size-3.5" aria-hidden="true" />
+            {submitting ? "判定中…" : "判定"}
+          </button>
         ) : null}
       </div>
+      {/* Mobile-only floating judge button — mirrors the WorkerProblemSolver
+          floating "実行" button so phones never lose access to the primary
+          action regardless of scroll position. */}
       {canJudge ? (
         <button
           type="button"
@@ -347,15 +374,15 @@ function SandpackJudgeBar({
           onClick={handleJudge}
           aria-label="判定する"
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-[8px] px-3.5 py-1.5 font-semibold text-[12.5px] transition",
+            "fixed right-4 bottom-16 z-30 inline-flex items-center gap-1.5 rounded-full px-5 py-3 font-semibold text-[13px] shadow-lg transition md:hidden",
             submitting ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
           )}
           style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
         >
-          <Play className="size-3.5" aria-hidden="true" />
+          <Play className="size-4" aria-hidden="true" />
           {submitting ? "判定中…" : "判定"}
         </button>
       ) : null}
-    </div>
+    </>
   );
 }

--- a/src/components/problem-solver/WorkerProblemSolver.tsx
+++ b/src/components/problem-solver/WorkerProblemSolver.tsx
@@ -1,0 +1,645 @@
+"use client";
+
+import { Check, ChevronDown, FileText, Play, RotateCcw, X } from "lucide-react";
+import dynamic from "next/dynamic";
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { KEY_NUDGE_PX, MAX_LEFT_RATIO, MIN_LEFT_PX } from "@/config/editor";
+import { cn } from "@/lib/utils";
+import { type ProblemStatus, type ProblemSubmitResult, useProblemRunner } from "./useProblemRunner";
+
+const MonacoEditor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
+
+export type WorkerProblemSolverProps = {
+  title: string;
+  contentMd: string;
+  starterCode: string;
+  expectedOutput: string | null;
+  onSubmit?: (result: ProblemSubmitResult) => Promise<void>;
+  initialStatus?: ProblemStatus;
+  /** Header chrome — left side (breadcrumb / back link). */
+  headerLeft?: ReactNode;
+  /** Small line displayed under the title. */
+  subtitle?: ReactNode;
+  /** Header chrome — right side, appended after the auto-rendered "クリア済み" badge. */
+  headerRight?: ReactNode;
+  /** Footer chrome — left side (e.g. prev / next nav). */
+  footerLeft?: ReactNode;
+  /** Footer chrome — center hint text (overrides the default). */
+  footerHint?: ReactNode;
+};
+
+export function WorkerProblemSolver({
+  title,
+  contentMd,
+  starterCode,
+  expectedOutput,
+  onSubmit,
+  initialStatus = "NOT_STARTED",
+  headerLeft,
+  subtitle,
+  headerRight,
+  footerLeft,
+  footerHint,
+}: WorkerProblemSolverProps) {
+  const { code, setCode, output, running, completed, run, reset } = useProblemRunner({
+    starterCode,
+    expectedOutput,
+    initialStatus,
+    onSubmit,
+  });
+
+  const passed =
+    completed ||
+    (!!output &&
+      !output.stderr &&
+      !output.timedOut &&
+      output.exitCode === 0 &&
+      expectedOutput !== null &&
+      output.stdout.trim() === expectedOutput.trim());
+
+  const splitRef = useRef<HTMLDivElement>(null);
+  const [leftWidth, setLeftWidth] = useState<number | null>(null);
+  const draggingRef = useRef(false);
+
+  // Result panel auto-opens after a successful run, but stays collapsible so
+  // the editor can use the full height while the user is typing.
+  const [resultExpanded, setResultExpanded] = useState(false);
+  const lastOutputRef = useRef(output);
+  useEffect(() => {
+    // Open the result drawer the moment a fresh output lands (Run completed).
+    if (output && output !== lastOutputRef.current) {
+      setResultExpanded(true);
+    }
+    lastOutputRef.current = output;
+  }, [output]);
+
+  const clampLeftWidth = useCallback((raw: number, containerWidth: number) => {
+    const max = Math.max(MIN_LEFT_PX, containerWidth * MAX_LEFT_RATIO);
+    return Math.max(MIN_LEFT_PX, Math.min(raw, max));
+  }, []);
+
+  const onResizerMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    draggingRef.current = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const onResizerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!splitRef.current) return;
+      const rect = splitRef.current.getBoundingClientRect();
+      const current = leftWidth ?? rect.width / 2;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        setLeftWidth(clampLeftWidth(current - KEY_NUDGE_PX, rect.width));
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        setLeftWidth(clampLeftWidth(current + KEY_NUDGE_PX, rect.width));
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        setLeftWidth(MIN_LEFT_PX);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        setLeftWidth(clampLeftWidth(rect.width * MAX_LEFT_RATIO, rect.width));
+      }
+    },
+    [leftWidth, clampLeftWidth],
+  );
+
+  useEffect(() => {
+    // Syncing drag state with window-level mouse events so dragging still works
+    // when the pointer leaves the resizer handle.
+    const onMove = (event: MouseEvent) => {
+      if (!draggingRef.current || !splitRef.current) return;
+      const rect = splitRef.current.getBoundingClientRect();
+      const raw = event.clientX - rect.left;
+      setLeftWidth(clampLeftWidth(raw, rect.width));
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [clampLeftWidth]);
+
+  const splitStyle: CSSProperties =
+    leftWidth !== null
+      ? { gridTemplateColumns: `${leftWidth}px 6px minmax(0,1fr)` }
+      : {
+          gridTemplateColumns: "minmax(280px, 1.2fr) 6px minmax(360px, 1fr)",
+        };
+
+  return (
+    <div
+      className="flex h-dvh flex-col overflow-hidden"
+      style={{ background: "var(--bg-0)", color: "var(--text-1)" }}
+    >
+      {/* Problem top bar */}
+      <header
+        className="grid flex-shrink-0 items-center gap-4 border-b px-5 py-2.5"
+        style={{
+          gridTemplateColumns: "1fr auto 1fr",
+          borderColor: "var(--line-1)",
+          background: "var(--bg-0)",
+        }}
+      >
+        <div className="flex items-center gap-3">{headerLeft}</div>
+        <div className="text-center">
+          <h1 className="m-0 font-semibold text-[15px] tracking-tight">{title}</h1>
+          {subtitle ? (
+            <div className="mt-0.5 font-mono text-[11px]" style={{ color: "var(--text-4)" }}>
+              {subtitle}
+            </div>
+          ) : null}
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          {passed ? (
+            <span
+              className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 font-semibold text-[11px]"
+              style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
+            >
+              <Check className="size-3" aria-hidden="true" /> クリア済み
+            </span>
+          ) : null}
+          {headerRight}
+        </div>
+      </header>
+
+      {/*
+        md+ : horizontal split — left = problem, right = editor (top, main area)
+        + collapsible result drawer (bottom). The drawer auto-expands on Run
+        completion, leaves the editor full-height when collapsed.
+        < md : body scrolls; problem → editor → result stacked, plus a fixed
+        Run button bottom-right.
+      */}
+      <div
+        ref={splitRef}
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto md:grid md:overflow-hidden"
+        style={splitStyle}
+      >
+        {/* LEFT pane: problem statement only */}
+        <div
+          className="flex min-h-[140px] flex-[1] flex-col overflow-visible border-b md:min-h-0 md:overflow-hidden md:border-b-0"
+          style={{ borderColor: "var(--line-1)", minWidth: 0 }}
+        >
+          {/* Problem statement */}
+          <div className="flex min-h-0 flex-1 flex-col overflow-visible md:overflow-hidden">
+            <div
+              className="flex flex-shrink-0 items-center gap-0.5 border-b px-3 py-1.5"
+              style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
+            >
+              <div
+                className="inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1.5 font-medium text-[12px]"
+                style={{ color: "var(--text-1)", background: "var(--bg-2)" }}
+              >
+                <FileText className="size-3.5" aria-hidden="true" /> 問題
+              </div>
+            </div>
+            <div className="flex-1 overflow-visible px-6 py-5 md:overflow-auto">
+              <div className="mx-auto max-w-[720px]" style={{ color: "var(--text-2)" }}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    h1: ({ children }) => (
+                      <h1
+                        className="mt-1 mb-4 font-bold text-[22px] tracking-tight"
+                        style={{ color: "var(--text-1)" }}
+                      >
+                        {children}
+                      </h1>
+                    ),
+                    h2: ({ children }) => (
+                      <h2
+                        className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
+                        style={{ color: "var(--text-1)" }}
+                      >
+                        {children}
+                      </h2>
+                    ),
+                    h3: ({ children }) => (
+                      <h3
+                        className="mt-5 mb-2 font-semibold text-[14px]"
+                        style={{ color: "var(--text-1)" }}
+                      >
+                        {children}
+                      </h3>
+                    ),
+                    p: ({ children }) => <p className="mb-3 leading-7 text-[13.5px]">{children}</p>,
+                    code: ({ className, children, ...rest }) => {
+                      // react-markdown v10+ no longer passes an `inline` prop. Treat a single
+                      // text node without a language class as inline; anything structural
+                      // (multi-line content, nested nodes) is a fenced block.
+                      const isInline =
+                        !className && typeof children === "string" && !children.includes("\n");
+                      return isInline ? (
+                        <code
+                          className="rounded px-1.5 py-0.5 font-mono text-[0.9em]"
+                          style={{
+                            background: "var(--bg-2)",
+                            color: "var(--accent-solid)",
+                            border: "1px solid var(--line-1)",
+                          }}
+                        >
+                          {children}
+                        </code>
+                      ) : (
+                        <code className={className} {...rest}>
+                          {children}
+                        </code>
+                      );
+                    },
+                    pre: ({ children }) => (
+                      <pre
+                        className="mb-4 overflow-x-auto rounded-[10px] p-3 font-mono text-[12.5px] leading-relaxed"
+                        style={{
+                          background: "var(--bg-code)",
+                          border: "1px solid var(--line-1)",
+                          color: "var(--text-1)",
+                        }}
+                      >
+                        {children}
+                      </pre>
+                    ),
+                    ul: ({ children }) => (
+                      <ul className="mb-3 list-disc space-y-1 pl-5">{children}</ul>
+                    ),
+                    ol: ({ children }) => (
+                      <ol className="mb-3 list-decimal space-y-1 pl-5">{children}</ol>
+                    ),
+                    a: ({ href, children }) => (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline"
+                        style={{ color: "var(--accent-solid)" }}
+                      >
+                        {children}
+                      </a>
+                    ),
+                    strong: ({ children }) => (
+                      <strong className="font-semibold" style={{ color: "var(--text-1)" }}>
+                        {children}
+                      </strong>
+                    ),
+                  }}
+                >
+                  {contentMd}
+                </ReactMarkdown>
+
+                {expectedOutput ? (
+                  <section className="mt-6">
+                    <h2
+                      className="mt-6 mb-2 font-semibold text-[15px] tracking-tight"
+                      style={{ color: "var(--text-1)" }}
+                    >
+                      期待される出力
+                    </h2>
+                    <div
+                      className="overflow-hidden rounded-[10px]"
+                      style={{
+                        background: "var(--bg-1)",
+                        border: "1px solid var(--line-1)",
+                      }}
+                    >
+                      <div
+                        className="border-b px-3 py-2 font-mono text-[11px]"
+                        style={{
+                          borderColor: "var(--line-1)",
+                          background: "var(--bg-2)",
+                          color: "var(--text-3)",
+                        }}
+                      >
+                        Expected stdout
+                      </div>
+                      <pre
+                        className="m-0 p-3 font-mono text-[12.5px] leading-relaxed"
+                        style={{ background: "var(--bg-code)", color: "var(--text-1)" }}
+                      >
+                        {expectedOutput}
+                      </pre>
+                    </div>
+                  </section>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Resizer (md+ only): adjusts left = problem / right = editor+result widths */}
+        {/* biome-ignore lint/a11y/useSemanticElements: ARIA separator role is required for split-pane resize handles; <hr> cannot host interactive behavior */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="問題ペインとエディタペインの横幅を調整"
+          aria-valuemin={MIN_LEFT_PX}
+          aria-valuemax={
+            splitRef.current
+              ? Math.max(
+                  MIN_LEFT_PX,
+                  splitRef.current.getBoundingClientRect().width * MAX_LEFT_RATIO,
+                )
+              : undefined
+          }
+          aria-valuenow={leftWidth ?? undefined}
+          tabIndex={0}
+          onMouseDown={onResizerMouseDown}
+          onKeyDown={onResizerKeyDown}
+          className="relative hidden cursor-col-resize touch-none items-center justify-center border-r border-l transition-colors hover:bg-[var(--bg-2)] focus-visible:bg-[var(--bg-2)] md:flex"
+          style={{
+            borderColor: "var(--line-1)",
+            background: "var(--bg-0)",
+          }}
+        >
+          <span
+            aria-hidden="true"
+            className="h-8 w-0.5 rounded"
+            style={{ background: "var(--line-2)" }}
+          />
+        </div>
+
+        {/* RIGHT pane: editor (main) + collapsible result drawer (bottom) */}
+        <div
+          className="flex min-h-[260px] flex-[1.4] flex-col overflow-hidden md:min-h-0 md:flex-1"
+          style={{ background: "var(--bg-code)", minWidth: 0 }}
+        >
+          {/* Editor toolbar */}
+          <div
+            className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-1.5"
+            style={{ background: "var(--bg-0)", borderColor: "var(--line-1)" }}
+          >
+            <div className="flex items-center gap-2 text-[12px]" style={{ color: "var(--text-3)" }}>
+              <span
+                className="rounded-[6px] px-2 py-0.5 font-mono text-[11px]"
+                style={{ background: "var(--bg-2)", border: "1px solid var(--line-1)" }}
+              >
+                TypeScript
+              </span>
+              <span className="font-mono">main.ts</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={reset}
+                className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-[12px] transition hover:bg-[var(--bg-2)]"
+                style={{ color: "var(--text-2)" }}
+              >
+                <RotateCcw className="size-3" aria-hidden="true" /> リセット
+              </button>
+              <button
+                type="button"
+                disabled={running}
+                onClick={run}
+                aria-label="コードを実行"
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-[8px] px-3.5 py-1.5 font-semibold text-[12.5px] transition",
+                  running ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
+                )}
+                style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
+              >
+                <Play className="size-3.5" aria-hidden="true" />
+                {running ? "実行中…" : "実行"}
+              </button>
+            </div>
+          </div>
+
+          {/* Monaco editor — main area, takes all remaining vertical space */}
+          <div className="relative flex-1" style={{ background: "var(--bg-code)", minHeight: 0 }}>
+            <MonacoEditor
+              height="100%"
+              language="typescript"
+              theme="vs-dark"
+              value={code}
+              onChange={(v) => setCode(v ?? "")}
+              options={{
+                minimap: { enabled: false },
+                fontSize: 13.5,
+                lineHeight: 22,
+                scrollBeyondLastLine: false,
+                smoothScrolling: true,
+                padding: { top: 12, bottom: 12 },
+                tabSize: 2,
+                fontFamily: "var(--font-mono-family)",
+                fontLigatures: true,
+              }}
+            />
+          </div>
+
+          {/* Collapsible result drawer */}
+          <div
+            className={cn(
+              "flex flex-shrink-0 flex-col border-t",
+              resultExpanded ? "h-[240px]" : "h-9",
+            )}
+            style={{ borderColor: "var(--line-1)", background: "var(--bg-0)" }}
+          >
+            <button
+              type="button"
+              onClick={() => setResultExpanded((prev) => !prev)}
+              className="flex flex-shrink-0 cursor-pointer items-center justify-between gap-2 border-b px-3 py-1.5 text-left transition-colors hover:bg-[var(--bg-2)]"
+              style={{ borderColor: resultExpanded ? "var(--line-1)" : "transparent" }}
+              aria-expanded={resultExpanded}
+              aria-controls="result-drawer-body"
+            >
+              <span
+                className="inline-flex items-center gap-2 text-[12px]"
+                style={{ color: "var(--text-3)" }}
+              >
+                <ChevronDown
+                  className={cn(
+                    "size-3.5 transition-transform",
+                    resultExpanded ? "" : "-rotate-90",
+                  )}
+                  aria-hidden="true"
+                />
+                実行結果
+                {running ? (
+                  <span
+                    className="cm-pulse inline-flex items-center gap-1 font-mono text-[11px]"
+                    style={{ color: "var(--text-3)" }}
+                  >
+                    ● 実行中…
+                  </span>
+                ) : output ? (
+                  <span
+                    className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 font-mono text-[11px]"
+                    style={{
+                      background: passed ? "var(--ok-soft)" : "var(--err-soft)",
+                      color: passed ? "var(--ok)" : "var(--err)",
+                    }}
+                  >
+                    {passed ? "Accepted" : "Wrong Answer"}
+                  </span>
+                ) : null}
+              </span>
+            </button>
+            {resultExpanded ? (
+              <div
+                id="result-drawer-body"
+                className="flex-1 overflow-auto p-4 font-mono text-[12px]"
+                style={{ color: "var(--text-1)" }}
+              >
+                <ResultBody output={output} expected={expectedOutput} passed={passed} />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile-only floating Run button — keeps the primary action one tap away
+          regardless of how far the user has scrolled the body on small screens. */}
+      <button
+        type="button"
+        disabled={running}
+        onClick={run}
+        aria-label="コードを実行"
+        className={cn(
+          "fixed right-4 bottom-16 z-30 inline-flex items-center gap-1.5 rounded-full px-5 py-3 font-semibold text-[13px] shadow-lg transition md:hidden",
+          running ? "cursor-not-allowed opacity-60" : "hover:opacity-90",
+        )}
+        style={{ background: "var(--accent-solid)", color: "var(--accent-ink)" }}
+      >
+        <Play className="size-4" aria-hidden="true" />
+        {running ? "実行中…" : "実行"}
+      </button>
+
+      {/* Bottom bar — navigation and hint only; the Run button now lives inside the editor toolbar */}
+      <footer
+        className="grid flex-shrink-0 items-center gap-4 border-t px-5 py-2"
+        style={{ gridTemplateColumns: "1fr auto 1fr", borderColor: "var(--line-1)" }}
+      >
+        <div className="flex gap-2">{footerLeft ?? <span />}</div>
+        <div
+          className="flex items-center gap-1.5 font-mono text-[11px]"
+          style={{ color: "var(--text-3)" }}
+        >
+          {footerHint ??
+            (expectedOutput ? "期待出力と一致すればクリア" : "実行して動作を確認しよう")}
+        </div>
+        <div />
+      </footer>
+    </div>
+  );
+}
+
+function ResultBody({
+  output,
+  expected,
+  passed,
+}: {
+  output: ReturnType<typeof useProblemRunner>["output"];
+  expected: string | null;
+  passed: boolean;
+}) {
+  if (!output) {
+    return (
+      <div className="py-10 text-center font-sans text-[13px]" style={{ color: "var(--text-3)" }}>
+        実行するとここに結果が表示されます
+      </div>
+    );
+  }
+
+  const hasStderr = !!output.stderr;
+  const hasStdout = !!output.stdout;
+
+  return (
+    <div className="space-y-3">
+      {expected !== null ? (
+        <div
+          className="flex items-center gap-2 rounded-[8px] px-3 py-2 font-sans text-[12.5px]"
+          style={{
+            background: passed ? "var(--ok-soft)" : "var(--err-soft)",
+            border: `1px solid ${passed ? "oklch(0.82 0.16 145 / 0.4)" : "oklch(0.72 0.19 25 / 0.4)"}`,
+            color: passed ? "var(--ok)" : "var(--err)",
+          }}
+        >
+          {passed ? (
+            <Check className="size-4" aria-hidden="true" />
+          ) : (
+            <X className="size-4" aria-hidden="true" />
+          )}
+          <b>{passed ? "Accepted — 期待出力と一致!" : "Wrong Answer — 期待出力と一致しません"}</b>
+        </div>
+      ) : null}
+
+      {hasStdout ? (
+        <div
+          className="overflow-hidden rounded-[8px]"
+          style={{ background: "var(--bg-1)", border: "1px solid var(--line-1)" }}
+        >
+          <div
+            className="border-b px-3 py-1.5 font-mono text-[11px]"
+            style={{
+              borderColor: "var(--line-1)",
+              background: "var(--bg-2)",
+              color: "var(--text-3)",
+            }}
+          >
+            stdout
+          </div>
+          <pre className="m-0 whitespace-pre-wrap break-all p-3" style={{ color: "var(--text-1)" }}>
+            {output.stdout}
+          </pre>
+        </div>
+      ) : null}
+
+      {hasStderr ? (
+        <div
+          className="overflow-hidden rounded-[8px]"
+          style={{ background: "var(--bg-1)", border: "1px solid oklch(0.72 0.19 25 / 0.4)" }}
+        >
+          <div
+            className="border-b px-3 py-1.5 font-mono text-[11px]"
+            style={{
+              borderColor: "var(--line-1)",
+              background: "var(--bg-2)",
+              color: "var(--err)",
+            }}
+          >
+            stderr
+          </div>
+          <pre className="m-0 whitespace-pre-wrap break-all p-3" style={{ color: "var(--err)" }}>
+            {output.stderr}
+          </pre>
+        </div>
+      ) : null}
+
+      {output.timedOut ? (
+        <div
+          className="rounded-[8px] px-3 py-2 font-sans text-[12.5px]"
+          style={{
+            background: "var(--warn-soft)",
+            border: "1px solid oklch(0.84 0.15 85 / 0.4)",
+            color: "var(--warn)",
+          }}
+        >
+          ⏱ タイムアウト (5s)
+        </div>
+      ) : null}
+
+      {!hasStdout && !hasStderr && !output.timedOut ? (
+        <div className="font-sans" style={{ color: "var(--text-3)" }}>
+          (出力なし)
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/sandpack.ts
+++ b/src/lib/sandpack.ts
@@ -1,0 +1,38 @@
+// Pure helpers to bridge Prisma's Json columns and the strongly-typed
+// SandpackTemplate / SandpackStarterFiles surfaces consumed by client
+// components. Kept framework-agnostic so it can be imported from Server
+// Components and Server Actions without dragging in `server-only`.
+
+import {
+  type SandpackStarterFiles,
+  SandpackStarterFilesSchema,
+  type SandpackTemplate,
+  SandpackTemplateSchema,
+} from "@/types/problem";
+
+type RawSandpackInput = {
+  sandpackTemplate: string | null;
+  starterFiles: unknown;
+};
+
+/**
+ * Validate the persisted `sandpack_template` / `starter_files` columns and
+ * narrow them to the typed unions the UI expects. Invalid rows fall back to
+ * `null` so the dispatch wrapper can render a clear error instead of crashing
+ * the page render.
+ */
+export function coerceSandpackFields(input: RawSandpackInput): {
+  sandpackTemplate: SandpackTemplate | null;
+  starterFiles: SandpackStarterFiles | null;
+} {
+  const templateResult = input.sandpackTemplate
+    ? SandpackTemplateSchema.safeParse(input.sandpackTemplate)
+    : null;
+  const filesResult = input.starterFiles
+    ? SandpackStarterFilesSchema.safeParse(input.starterFiles)
+    : null;
+  return {
+    sandpackTemplate: templateResult?.success ? templateResult.data : null,
+    starterFiles: filesResult?.success ? filesResult.data : null,
+  };
+}

--- a/src/repositories/lesson.repository.ts
+++ b/src/repositories/lesson.repository.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
-import type { Lesson } from "@prisma/client";
+import type { Lesson, LessonExecutor } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { BaseRepository } from "./base.repository";
 
 export type CreateLessonInput = {
@@ -12,6 +13,9 @@ export type CreateLessonInput = {
   expectedOutput: string | null;
   order: number;
   isPublished?: boolean;
+  executor?: LessonExecutor;
+  sandpackTemplate?: string | null;
+  starterFiles?: Prisma.InputJsonValue | null;
 };
 
 export type UpdateLessonInput = {
@@ -21,6 +25,9 @@ export type UpdateLessonInput = {
   starterCode?: string;
   expectedOutput?: string | null;
   order?: number;
+  executor?: LessonExecutor;
+  sandpackTemplate?: string | null;
+  starterFiles?: Prisma.InputJsonValue | null;
 };
 
 export class LessonRepository extends BaseRepository {
@@ -53,14 +60,21 @@ export class LessonRepository extends BaseRepository {
         expectedOutput: input.expectedOutput,
         order: input.order,
         isPublished: input.isPublished ?? false,
+        executor: input.executor ?? "WORKER",
+        sandpackTemplate: input.sandpackTemplate ?? null,
+        starterFiles: toPrismaJson(input.starterFiles),
       },
     });
   }
 
   async update(id: string, input: UpdateLessonInput): Promise<Lesson> {
+    const { starterFiles, ...rest } = input;
     return this.client.lesson.update({
       where: { id },
-      data: input,
+      data: {
+        ...rest,
+        ...(starterFiles === undefined ? {} : { starterFiles: toPrismaJson(starterFiles) }),
+      },
     });
   }
 
@@ -74,4 +88,13 @@ export class LessonRepository extends BaseRepository {
       data: { isPublished },
     });
   }
+}
+
+function toPrismaJson(
+  value: Prisma.InputJsonValue | null | undefined,
+): Prisma.InputJsonValue | typeof Prisma.DbNull {
+  if (value === null || value === undefined) {
+    return Prisma.DbNull;
+  }
+  return value;
 }

--- a/src/repositories/problem.repository.ts
+++ b/src/repositories/problem.repository.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
-import type { Problem } from "@prisma/client";
+import type { LessonExecutor, Problem } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { BaseRepository } from "./base.repository";
 
 export type CreateProblemInput = {
@@ -12,6 +13,9 @@ export type CreateProblemInput = {
   expectedOutput: string | null;
   order: number;
   isPublished?: boolean;
+  executor?: LessonExecutor;
+  sandpackTemplate?: string | null;
+  starterFiles?: Prisma.InputJsonValue | null;
 };
 
 export type UpdateProblemInput = {
@@ -21,6 +25,9 @@ export type UpdateProblemInput = {
   starterCode?: string;
   expectedOutput?: string | null;
   order?: number;
+  executor?: LessonExecutor;
+  sandpackTemplate?: string | null;
+  starterFiles?: Prisma.InputJsonValue | null;
 };
 
 export class ProblemRepository extends BaseRepository {
@@ -53,14 +60,21 @@ export class ProblemRepository extends BaseRepository {
         expectedOutput: input.expectedOutput,
         order: input.order,
         isPublished: input.isPublished ?? false,
+        executor: input.executor ?? "WORKER",
+        sandpackTemplate: input.sandpackTemplate ?? null,
+        starterFiles: toPrismaJson(input.starterFiles),
       },
     });
   }
 
   async update(id: string, input: UpdateProblemInput): Promise<Problem> {
+    const { starterFiles, ...rest } = input;
     return this.client.problem.update({
       where: { id },
-      data: input,
+      data: {
+        ...rest,
+        ...(starterFiles === undefined ? {} : { starterFiles: toPrismaJson(starterFiles) }),
+      },
     });
   }
 
@@ -74,4 +88,16 @@ export class ProblemRepository extends BaseRepository {
       data: { isPublished },
     });
   }
+}
+
+// `null` clears the JSON column, `undefined` leaves it untouched, but the
+// Prisma JSON types treat `null` specially via `Prisma.DbNull`. This helper
+// normalizes the trio so callers can pass plain JSON objects.
+function toPrismaJson(
+  value: Prisma.InputJsonValue | null | undefined,
+): Prisma.InputJsonValue | typeof Prisma.DbNull {
+  if (value === null || value === undefined) {
+    return Prisma.DbNull;
+  }
+  return value;
 }

--- a/src/services/problemService.ts
+++ b/src/services/problemService.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import type { Problem } from "@prisma/client";
+import type { LessonExecutor, Prisma, Problem } from "@prisma/client";
 import { ForbiddenError, handleUnknownError, NotFoundError, ValidationError } from "@/lib/errors";
 import { logError, logInfo, logWarn } from "@/lib/logging";
 import {
@@ -57,6 +57,9 @@ export type CreateProblemParams = {
   starterCode: string;
   expectedOutput: string | null;
   order: number;
+  executor: LessonExecutor;
+  sandpackTemplate: string | null;
+  starterFiles: Prisma.InputJsonValue | null;
 };
 
 export async function createProblem(
@@ -64,9 +67,20 @@ export async function createProblem(
   repository: ProblemRepository = problemRepository,
   collectionRepo: CollectionRepository = collectionRepository,
 ): Promise<Problem> {
-  const { collectionId, authorId, slug, title, contentMd, starterCode, expectedOutput, order } =
-    params;
-  logInfo("problemService.createProblem.start", { collectionId, authorId, slug });
+  const {
+    collectionId,
+    authorId,
+    slug,
+    title,
+    contentMd,
+    starterCode,
+    expectedOutput,
+    order,
+    executor,
+    sandpackTemplate,
+    starterFiles,
+  } = params;
+  logInfo("problemService.createProblem.start", { collectionId, authorId, slug, executor });
   try {
     await ensureAuthorOwnsCollection(collectionId, authorId, collectionRepo);
     const problem = await repository.create({
@@ -77,6 +91,9 @@ export async function createProblem(
       starterCode,
       expectedOutput,
       order,
+      executor,
+      sandpackTemplate,
+      starterFiles,
     });
     logInfo("problemService.createProblem.success", { id: problem.id, collectionId });
     return problem;
@@ -104,6 +121,9 @@ export type UpdateProblemParams = {
   starterCode: string;
   expectedOutput: string | null;
   order: number;
+  executor: LessonExecutor;
+  sandpackTemplate: string | null;
+  starterFiles: Prisma.InputJsonValue | null;
 };
 
 export async function updateProblem(
@@ -111,8 +131,20 @@ export async function updateProblem(
   repository: ProblemRepository = problemRepository,
   collectionRepo: CollectionRepository = collectionRepository,
 ): Promise<Problem> {
-  const { id, authorId, slug, title, contentMd, starterCode, expectedOutput, order } = params;
-  logInfo("problemService.updateProblem.start", { id, authorId });
+  const {
+    id,
+    authorId,
+    slug,
+    title,
+    contentMd,
+    starterCode,
+    expectedOutput,
+    order,
+    executor,
+    sandpackTemplate,
+    starterFiles,
+  } = params;
+  logInfo("problemService.updateProblem.start", { id, authorId, executor });
   try {
     await ensureAuthorOwnsProblem(id, authorId, repository, collectionRepo);
     const problem = await repository.update(id, {
@@ -122,6 +154,9 @@ export async function updateProblem(
       starterCode,
       expectedOutput,
       order,
+      executor,
+      sandpackTemplate,
+      starterFiles,
     });
     logInfo("problemService.updateProblem.success", { id, authorId });
     return problem;

--- a/src/types/problem.ts
+++ b/src/types/problem.ts
@@ -6,6 +6,37 @@ export const ProblemSlugSchema = z
   .max(64)
   .regex(/^[a-z0-9][a-z0-9-]*$/, "slug は小文字英数字とハイフンのみ");
 
+export const ExecutorSchema = z.enum(["WORKER", "SANDPACK"]);
+export type Executor = z.infer<typeof ExecutorSchema>;
+
+// Curated Sandpack template list. Sandpack supports more, but limiting the
+// authoring surface keeps the runtime asset budget predictable and lets us
+// add templates intentionally.
+export const SandpackTemplateSchema = z.enum([
+  "react",
+  "react-ts",
+  "vue",
+  "vue-ts",
+  "vanilla",
+  "vanilla-ts",
+  "vite",
+  "vite-react",
+  "vite-react-ts",
+  "vite-vue",
+  "vite-vue-ts",
+]);
+export type SandpackTemplate = z.infer<typeof SandpackTemplateSchema>;
+
+export const SandpackStarterFilesSchema = z
+  .record(
+    z.string().min(1).regex(/^\//, "Sandpack file path must start with '/'"),
+    z.string().max(50_000),
+  )
+  .refine((files) => Object.keys(files).length > 0, {
+    message: "starterFiles に最低 1 ファイル必要です",
+  });
+export type SandpackStarterFiles = z.infer<typeof SandpackStarterFilesSchema>;
+
 const ProblemBaseFields = {
   slug: ProblemSlugSchema,
   title: z.string().min(1).max(120),
@@ -13,17 +44,51 @@ const ProblemBaseFields = {
   starterCode: z.string().max(50_000),
   expectedOutput: z.string().max(10_000).nullable(),
   order: z.number().int().min(0).max(10_000),
+  executor: ExecutorSchema.default("WORKER"),
+  sandpackTemplate: SandpackTemplateSchema.nullable().default(null),
+  starterFiles: SandpackStarterFilesSchema.nullable().default(null),
 } as const;
 
-export const CreateProblemSchema = z.object({
-  collectionId: z.cuid(),
-  ...ProblemBaseFields,
-});
+// SANDPACK requires both template and starter files; WORKER does not use them.
+// Enforced server-side regardless of UI gating.
+const executorPayloadCheck = (
+  data: {
+    executor: Executor;
+    sandpackTemplate: SandpackTemplate | null;
+    starterFiles: SandpackStarterFiles | null;
+  },
+  ctx: z.RefinementCtx,
+) => {
+  if (data.executor !== "SANDPACK") return;
+  if (!data.sandpackTemplate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["sandpackTemplate"],
+      message: "SANDPACK では sandpackTemplate が必須です",
+    });
+  }
+  if (!data.starterFiles) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["starterFiles"],
+      message: "SANDPACK では starterFiles が必須です",
+    });
+  }
+};
 
-export const UpdateProblemSchema = z.object({
-  id: z.cuid(),
-  ...ProblemBaseFields,
-});
+export const CreateProblemSchema = z
+  .object({
+    collectionId: z.cuid(),
+    ...ProblemBaseFields,
+  })
+  .superRefine(executorPayloadCheck);
+
+export const UpdateProblemSchema = z
+  .object({
+    id: z.cuid(),
+    ...ProblemBaseFields,
+  })
+  .superRefine(executorPayloadCheck);
 
 export const DeleteProblemSchema = z.object({
   id: z.cuid(),


### PR DESCRIPTION
## Summary

- `LessonExecutor` enum + `executor` / `sandpackTemplate` / `starterFiles` columns on `Lesson` と `Problem`。既存行は default `WORKER` のまま動く (regression なし)。
- `ProblemSolver` を dispatcher に変え、`WorkerProblemSolver`（既存の esbuild-wasm + Monaco）と新規 `SandpackProblemSolver`（Sandpack iframe + テキスト判定）を分離。Sandpack は `next/dynamic { ssr: false }` でチャンク分離され、WORKER レッスンには一切ロードされない。
- 公式コース `react-fundamentals` に SANDPACK デモレッスン「Counter コンポーネント」を 1 本追加。判定は `useState`/`onClick` などキーワードの textual check。
- Dashboard の問題作成/編集フォームに `executor` ラジオ + Sandpack 用フィールド (template select, starter files JSON editor, 判定キーワード) を追加。

## Schema

```prisma
enum LessonExecutor { WORKER SANDPACK }

model Lesson  { executor LessonExecutor @default(WORKER) sandpackTemplate String? starterFiles Json? ... }
model Problem { executor LessonExecutor @default(WORKER) sandpackTemplate String? starterFiles Json? ... }
```

Migration: `prisma/migrations/20260429234108_add_lesson_executor/`. Supabase 反映は **未実施**。マージ後に `npm run db:migrate:deploy` で適用してください。

## Phase 2 (#14) との関係

本 PR は Phase 1 = Sandpack のみ。Phase 2 (Vercel Sandbox) はこのスキーマの上に enum 値を追加して派生させる想定で、本 PR では着手しません。

## Test plan

- [ ] `npm run check && npm run build` (TypeScript 含む) pass — ローカル確認済み
- [ ] migration ファイルが `prisma migrate diff --from-migrations --to-schema --exit-code` で no-diff
- [ ] `prisma migrate deploy` を Supabase に適用し、デモレッスン `/learn/react-fundamentals/counter` を開いて Sandpack iframe が動作する
- [ ] 既存 WORKER レッスン (例: `/learn/ts-intro/hello-world`) が以前通り動作（Monaco + Run + 期待出力比較）
- [ ] Dashboard で WORKER 問題が以前通り作成/編集できる
- [ ] Dashboard で SANDPACK 問題を作成し、starterFiles JSON / 判定キーワードを保存して反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)